### PR TITLE
24 add typedef functionality

### DIFF
--- a/source/StepBro.Core/Parser/FileBuilder.cs
+++ b/source/StepBro.Core/Parser/FileBuilder.cs
@@ -318,6 +318,7 @@ namespace StepBro.Core.Parser
                 addonManager.AddAssembly(typeof(Enumerable).Assembly, false);
             }
             addonManager.AddAssembly(AddonManager.StepBroCoreAssembly, true);   // Add StepBro.Core always.
+            addonManager.AddAssembly(typeof(System.Array).Assembly, false);
             if (usingType != null)
             {
                 addonManager.AddAssembly(usingType.Assembly, false);

--- a/source/StepBro.Core/Parser/SBExpressionData.cs
+++ b/source/StepBro.Core/Parser/SBExpressionData.cs
@@ -21,6 +21,7 @@ namespace StepBro.Core.Parser
         LocalVariableReference,
         Indexing,
         TypeReference,
+        GenericTypeDefinition,
         PropertyReference,
         MethodReference,
         ScriptNamespace,

--- a/source/StepBro.Core/Parser/StepBro.g4
+++ b/source/StepBro.Core/Parser/StepBro.g4
@@ -35,6 +35,7 @@ fileElement
         |	testlist
         |	datatable
         |   fileElementOverride
+        |   typedef
         ) 
     ;
 
@@ -76,7 +77,17 @@ elementModifier
 
 fileElementReference : identifierOrQualified ;
 
-fileElementOverride : OVERRIDE fileElementReference elementPropertyblock ;
+fileElementOverride : OVERRIDE fileElementReference typeOverride? elementPropertyblock? ;
+
+typeOverride : AS typedefName ;
+
+typedefName : IDENTIFIER ;
+
+typedef 
+    : TYPEDEF typedefName typedefType SEMICOLON       // NOT LIKE A TYPEDEF IN C/C++; NAME FIRST HERE!!
+    ;
+
+typedefType : typeSimpleOrGeneric ;
 
 fileVariable
     :   elementModifier? variableType variableDeclaratorId elementPropertyblock         #FileVariableWithPropertyBlock
@@ -86,14 +97,6 @@ fileVariable
 //modifiers
     //:   modifier*
     //;
-
-//typeParameters
-//    :   '<' typeParameter (',' typeParameter)* '>'
-//    ;
-
-//typeParameter
-//    :   Identifier ('extends' typeBound)?
-//    ;
 
 // ENUM DECLARATION
 
@@ -260,6 +263,14 @@ primitiveType
 
 typeReference : TYPEOF OPEN_PARENS type CLOSE_PARENS ;
 
+typeSimpleOrGeneric
+    : type typeParameters       # TypeGeneric
+    | type                      # TypeSimple
+    ;
+
+typeParameters : LT typeParameter (COMMA typeParameter)* GT ;
+
+typeParameter : typeSimpleOrGeneric ;
 
 //qualifiedNameList
 //    :   identifierOrQualified (COMMA identifierOrQualified)*
@@ -646,7 +657,8 @@ expression
     |   ( op=TILDE | op=BANG | op=NOT ) expression						# ExpUnaryRight
     |   OPEN_PARENS type CLOSE_PARENS expression						# ExpCast
     |   AWAIT expression                                                # ExpAwait
-    //|   'new' creator
+
+    //|   NEW creator
 
     |	expression 
         (op1=OP_LE|op1=OP_LT_APPROX|op1=LT) 

--- a/source/StepBro.Core/Parser/StepBroLexer.g4
+++ b/source/StepBro.Core/Parser/StepBroLexer.g4
@@ -40,6 +40,7 @@ SHARP:						'#'						-> mode(DIRECTIVE_MODE);
 
 // Keywords
 
+AS : 'as' ;
 ALT : 'alt' ;
 ASSERT : 'assert' ;
 AWAIT : 'await' ;

--- a/source/StepBro.Core/Parser/StepBroListener.Identifier.cs
+++ b/source/StepBro.Core/Parser/StepBroListener.Identifier.cs
@@ -497,6 +497,19 @@ namespace StepBro.Core.Parser
                         }
                         break;
 
+                    case FileElementType.TypeDef:
+                        {
+                            var typedef = element as FileElementTypeDef;
+
+                            result = new SBExpressionData(
+                                HomeType.Immediate,
+                                SBExpressionType.TypeReference,
+                                typedef.DataType,
+                                null,
+                                typedef);
+                        }
+                        break;
+
                     default:
                         throw new NotImplementedException();
                 }

--- a/source/StepBro.Core/Parser/StepBroListener.Identifier.cs
+++ b/source/StepBro.Core/Parser/StepBroListener.Identifier.cs
@@ -601,8 +601,16 @@ namespace StepBro.Core.Parser
                 }
                 else
                 {
-                    //throw new Exception("Sub-namespace was not found (" + right + ").");
-                    return null;
+                    var gtName = rightString + "`";
+                    var genericTypedefs = left.NamespaceList.ListTypes(false).Where(ti => ti.Name.StartsWith(gtName)).ToList();
+                    if (genericTypedefs.Count > 0)
+                    {
+                        return new SBExpressionData(HomeType.Immediate, SBExpressionType.GenericTypeDefinition, (TypeReference)null, value: genericTypedefs, token: right.Token);
+                    }
+                    else
+                    {
+                        return null;
+                    }
                 }
             }
         }

--- a/source/StepBro.Core/Parser/StepBroListener.Variable.cs
+++ b/source/StepBro.Core/Parser/StepBroListener.Variable.cs
@@ -69,7 +69,9 @@ namespace StepBro.Core.Parser
                 }
                 else if (m_variableType.Type.IsClass)
                 {
-                    throw new NotImplementedException();
+                    var defaultConstructor = m_variableType.Type.GetConstructor(new Type[0]);
+                    var newExpression = Expression.New(defaultConstructor);
+                    m_variableInitializer = new SBExpressionData(newExpression);
                 }
             }
         }

--- a/source/StepBro.Core/Parser/StepBroListener.cs
+++ b/source/StepBro.Core/Parser/StepBroListener.cs
@@ -1,4 +1,6 @@
-﻿using Antlr4.Runtime;
+﻿//#define PRINT_TREE
+
+using Antlr4.Runtime;
 using Antlr4.Runtime.Misc;
 using Antlr4.Runtime.Tree;
 using Newtonsoft.Json.Serialization;
@@ -133,6 +135,10 @@ namespace StepBro.Core.Parser
             m_lastElementPropertyBlock = null;
             m_fileElementModifier = AccessModifier.Private;    // Default is 'private'.
             m_currentFileElement = null;
+
+#if (PRINT_TREE)
+            m_indent = m_indent.Substring(0, m_indent.Length - 4) + "|   ";
+#endif
         }
 
         public override void EnterElementModifier([NotNull] SBP.ElementModifierContext context)
@@ -257,7 +263,7 @@ namespace StepBro.Core.Parser
                     }
                 }
                 #endregion
-                
+
                 #region Reset Action
                 var resettable = type.Type.GetInterface(nameof(IResettable));
                 if (resettable != null)
@@ -687,25 +693,43 @@ namespace StepBro.Core.Parser
             }
         }
 
+#if (PRINT_TREE)
+        private string m_indent = "";
+
         public override void EnterEveryRule([NotNull] ParserRuleContext context)
         {
-            base.EnterEveryRule(context);
-            //var txt = context.GetText();
-            //var lf = txt.IndexOf('\r');
-            //if (lf > 0) txt = txt.Substring(0, lf);
-            //else if (txt.Length > 40) txt = txt.Substring(0, 40);
-            //System.Diagnostics.Debug.WriteLine("ENTER " + context.GetType().Name + "  : " + txt);
+            System.Diagnostics.Debug.WriteLine(m_indent + "Enter" + this.ContextName(context) + ":             " + this.ShortContextText(context));
+            m_indent += "    ";
         }
 
         public override void ExitEveryRule([NotNull] ParserRuleContext context)
         {
-            //System.Diagnostics.Debug.WriteLine("EXIT " + context.GetType().Name);
-            base.ExitEveryRule(context);
+            m_indent = m_indent.Substring(0, m_indent.Length - 4);
+            //Console.WriteLine(m_indent + "EXIT  - " + this.ContextName(context) + ":             " + this.ShortContextText(context));
         }
+
+        private string ShortContextText(ParserRuleContext context)
+        {
+            string text = context.GetText();
+            if (text.Length > 80)
+            {
+                text = text.Substring(0, 75) + " ... " + text.Substring(text.Length - 10);
+            }
+            return text;
+        }
+
+        private string ContextName(ParserRuleContext context)
+        {
+            string name = context.GetType().Name;
+            return name.Substring(0, name.Length - "Context".Length);
+        }
+#endif
 
         public override void VisitErrorNode([NotNull] IErrorNode node)
         {
-            //System.Diagnostics.Debug.WriteLine(node.Payload.GetType().Name);
+#if (PRINT_TREE)
+            System.Diagnostics.Debug.WriteLine(m_indent + "ERROR - " + node.GetText());
+#endif
             //var t = node.Payload as CommonToken;
             //if (t != null)
             //{

--- a/source/StepBro.Core/Parser/StepBroListener.cs
+++ b/source/StepBro.Core/Parser/StepBroListener.cs
@@ -27,6 +27,7 @@ namespace StepBro.Core.Parser
         private Stack<ElementType> m_currentElementType = new Stack<ElementType>();
         protected AccessModifier m_fileElementModifier = AccessModifier.None;
         protected IToken m_elementStart = null;
+        protected string m_name = null;
         protected string m_currentNamespace = null;
         protected FileTestList m_currentTestList = null;
         protected Stack<SBExpressionData> m_testListEntryArguments = null;
@@ -141,6 +142,41 @@ namespace StepBro.Core.Parser
             else if (modifier == "private") m_fileElementModifier = AccessModifier.Private;
             else if (modifier == "protected") m_fileElementModifier = AccessModifier.Protected;
             else throw new NotImplementedException();
+        }
+
+        public override void EnterTypedef([NotNull] SBP.TypedefContext context)
+        {
+            //var fileElement = new FileElementTypeDef(m_file, context.Start.Line, )
+            m_currentFileElement = new FileElementTypeDef(m_file, context.Start.Line, m_currentNamespace, "");
+            m_name = null;
+        }
+
+        public override void ExitTypedef([NotNull] SBP.TypedefContext context)
+        {
+            m_currentFileElement.SetName(m_currentNamespace, m_name);
+        }
+
+        public override void ExitTypedefName([NotNull] SBP.TypedefNameContext context)
+        {
+            m_name = context.GetText();
+        }
+
+        public override void EnterTypedefType([NotNull] SBP.TypedefTypeContext context)
+        {
+            m_expressionData.PushStackLevel("TypeDefOuterType");
+        }
+
+        public override void ExitTypedefType([NotNull] SBP.TypedefTypeContext context)
+        {
+            m_expressionData.PopStackLevel();
+            var type = m_typeStack.Pop();
+
+            // TODO: Set the type in the FileElementTypedef
+        }
+
+        public override void ExitTypeOverride([NotNull] SBP.TypeOverrideContext context)
+        {
+            // TODO: set the override type for the current file element (variable). Use m_name.
         }
 
         public override void EnterFileVariableWithPropertyBlock([NotNull] SBP.FileVariableWithPropertyBlockContext context)

--- a/source/StepBro.Core/ScriptData/FileElementTypeDef.cs
+++ b/source/StepBro.Core/ScriptData/FileElementTypeDef.cs
@@ -1,4 +1,5 @@
 ﻿using StepBro.Core.Data;
+using StepBro.Core.Parser;
 using System;
 
 namespace StepBro.Core.ScriptData
@@ -7,8 +8,12 @@ namespace StepBro.Core.ScriptData
     {
         private TypeReference m_datatype = null;
 
-        public FileElementTypeDef(IScriptFile file, int line, string @namespace, string name, TypeReference type)
+        public FileElementTypeDef(IScriptFile file, int line, string @namespace, string name)
             : base(file, line, null, @namespace, name, AccessModifier.None, FileElementType.TypeDef)
+        {
+        }
+
+        public void SetType(TypeReference type)
         {
             if (type == null) throw new ArgumentNullException("type");
             if (!type.IsTypedef()) throw new ArgumentException("Type must be a 'TypeDef'.");
@@ -18,6 +23,11 @@ namespace StepBro.Core.ScriptData
         protected override TypeReference GetDataType()
         {
             return m_datatype;
+        }
+
+        internal override int ParseSignature(StepBroListener listener, bool reportErrors)
+        {
+            return base.ParseSignature(listener, reportErrors);
         }
     }
 }

--- a/source/StepBro.Core/ScriptData/FileElementTypeDef.cs
+++ b/source/StepBro.Core/ScriptData/FileElementTypeDef.cs
@@ -6,28 +6,44 @@ namespace StepBro.Core.ScriptData
 {
     internal class FileElementTypeDef : FileElement
     {
-        private TypeReference m_datatype = null;
+        private StepBroTypeScanListener.ScannedTypeDescriptor m_declaration = null;
+        private TypeReference m_typeReference = null;
 
         public FileElementTypeDef(IScriptFile file, int line, string @namespace, string name)
             : base(file, line, null, @namespace, name, AccessModifier.None, FileElementType.TypeDef)
         {
+            System.Diagnostics.Debug.WriteLine("TYPEDEF");
         }
 
-        public void SetType(TypeReference type)
+        public void SetDeclaration(StepBroTypeScanListener.ScannedTypeDescriptor declaration)
         {
-            if (type == null) throw new ArgumentNullException("type");
-            if (!type.IsTypedef()) throw new ArgumentException("Type must be a 'TypeDef'.");
-            m_datatype = type;
+            m_declaration = declaration;
         }
+
+        //public void SetType(TypeReference type)
+        //{
+        //    if (type == null) throw new ArgumentNullException("type");
+        //    if (!type.IsTypedef()) throw new ArgumentException("Type must be a 'TypeDef'.");
+        //    m_datatype = type;
+        //}
 
         protected override TypeReference GetDataType()
         {
-            return m_datatype;
+            return m_typeReference;
         }
 
         internal override int ParseSignature(StepBroListener listener, bool reportErrors)
         {
-            return base.ParseSignature(listener, reportErrors);
+            if (m_declaration.ResolvedType == null)
+            {
+                var numUnresolved = listener.ParseTypedef(m_declaration, reportErrors: reportErrors, token: m_declaration.Token);
+                if (numUnresolved == 0 && m_declaration.ResolvedType != null)
+                {
+                    m_typeReference = new TypeReference(new TypeDef(this.Name, m_declaration.ResolvedType));
+                }
+                return numUnresolved;
+            }
+            return 0;
         }
     }
 }

--- a/source/StepBro.Core/ScriptData/ScriptFile.cs
+++ b/source/StepBro.Core/ScriptData/ScriptFile.cs
@@ -535,6 +535,11 @@ namespace StepBro.Core.ScriptData
             m_elements.Add(overrider);
         }
 
+        internal void AddTypedef(FileElementTypeDef def)
+        {
+            m_elements.Add(def);
+        }
+
         public IEnumerable<IFileElement> ListElements()
         {
             foreach (var e in m_fileScopeVariables)

--- a/source/Test/StepBro.Core.Test/Parser/Expression/TestMethodCall.cs
+++ b/source/Test/StepBro.Core.Test/Parser/Expression/TestMethodCall.cs
@@ -289,5 +289,15 @@ namespace StepBroCoreTest.Parser
             Assert.AreEqual(70L + 928L, ParseAndRun<long>("varDummyA.MethodWithCallContextB(\"Upsan\")", varDummyClass: true));
             Assert.AreEqual(70L + 726L, ParseAndRun<long>("varDummyB.MethodWithCallContextB(\"Upsan\")", varDummyClass: true));
         }
+
+        [TestMethod]
+        public void TestSystemRandom()
+        {
+            Assert.AreEqual(25L, ParseAndRun<long>(
+                "value",
+                "var rnd = new Random(); " +
+                "var value = rnd.Next(0, 100);",
+                false));
+        }
     }
 }

--- a/source/Test/StepBro.Core.Test/Parser/TestFileParsing.cs
+++ b/source/Test/StepBro.Core.Test/Parser/TestFileParsing.cs
@@ -321,7 +321,7 @@ namespace StepBroCoreTest.Parser
             var taskContext = ExecutionHelper.ExeContext(services: FileBuilder.LastServiceManager.Manager);
 
             var result = taskContext.CallProcedure(proc);
-            Assert.AreEqual("Bente", result);
+            Assert.AreEqual("Bent", result);
         }
     }
 }

--- a/source/Test/StepBro.Core.Test/Parser/TestFileParsing.cs
+++ b/source/Test/StepBro.Core.Test/Parser/TestFileParsing.cs
@@ -220,71 +220,108 @@ namespace StepBroCoreTest.Parser
         {
             var f1 = new StringBuilder();
             f1.AppendLine("using " + typeof(DummyInstrumentClass).Namespace + ";");  // An object with the IResettable interface.
-            f1.AppendLine("using \"libfile.sbs\";");
-            f1.AppendLine("namespace TypedefTest;");
+            f1.AppendLine("typedef MyToolType " + typeof(DummyInstrumentClass).Name + ";");
             f1.AppendLine("MyToolType myTool");
             f1.AppendLine("{");
             f1.AppendLine("   IntA:  72");
             f1.AppendLine("}");
             f1.AppendLine("procedure int TopGetValue() { return myTool.IntA; }");
 
-            var f2 = new StringBuilder();
-            f2.AppendLine("using " + typeof(DummyInstrumentClass).Namespace + ";");  // An object with the IResettable interface.
-            f2.AppendLine("namespace TypedefTest;");
-            f2.AppendLine("public typedef MyToolType " + typeof(DummyInstrumentClass).Name + ";");
-
             var files = FileBuilder.ParseFiles((ILogger)null, this.GetType().Assembly,
-                new Tuple<string, string>("topfile.sbs", f1.ToString()),
-                new Tuple<string, string>("libfile.sbs", f2.ToString()));
-            Assert.AreEqual(2, files.Length);
-            Assert.AreEqual("topfile.sbs", files[0].FileName);
-            Assert.AreEqual("libfile.sbs", files[1].FileName);
+                new Tuple<string, string>("myfile.sbs", f1.ToString()));
+            Assert.AreEqual(1, files.Length);
             Assert.AreEqual(0, files[0].Errors.ErrorCount);
-            Assert.AreEqual(0, files[1].Errors.ErrorCount);
-            var procedureTop = files[0].ListElements().First(p => p.Name == "TopGetValue") as IFileProcedure;
-            Assert.IsNotNull(procedureTop);
-            var element = files[1].ListElements().First(p => p.Name == "myTool") as IFileElement;
+            var typedef = files[0].ListElements().FirstOrDefault(p => p.Name == "MyToolType");
+            Assert.IsNotNull(typedef);
+            Assert.IsNotNull(typedef.DataType);
+            var procedure = files[0].ListElements().FirstOrDefault(p => p.Name == "TopGetValue") as IFileProcedure;
+            Assert.IsNotNull(procedure);
+            var element = files[0].ListElements().FirstOrDefault(p => p.Name == "myTool");
             Assert.IsNotNull(element);
 
             var taskContext = ExecutionHelper.ExeContext(services: FileBuilder.LastServiceManager.Manager);
 
-            var result = taskContext.CallProcedure(procedureTop);
+            var result = taskContext.CallProcedure(procedure);
             Assert.AreEqual(72L, result);
+        }
+
+        [TestMethod]
+        public void FileParsing_TypeDefSimplePublic()
+        {
+            var f1 = new StringBuilder();
+            f1.AppendLine("using \"lib3file.sbs\";");
+            f1.AppendLine("namespace TypedefTest;");
+            f1.AppendLine("MyThirdToolType myTool");
+            f1.AppendLine("{");
+            f1.AppendLine("   IntA:  91");
+            f1.AppendLine("}");
+            f1.AppendLine("procedure int TopGetValue() { return myTool.IntA; }");
+
+            var f2 = new StringBuilder();
+            f2.AppendLine("using \"lib2file.sbs\";");
+            f2.AppendLine("namespace TypedefTest;");
+            f2.AppendLine("public typedef MyThirdToolType MySecondToolType;");
+
+            var f3 = new StringBuilder();
+            f3.AppendLine("using \"lib1file.sbs\";");
+            f3.AppendLine("namespace TypedefTest;");
+            f3.AppendLine("public typedef MySecondToolType MyFirstToolType;");
+
+            var f4 = new StringBuilder();
+            f4.AppendLine("using " + typeof(DummyInstrumentClass).Namespace + ";");  // An object with the IResettable interface.
+            f4.AppendLine("namespace TypedefTest;");
+            f4.AppendLine("public typedef MyFirstToolType " + typeof(DummyInstrumentClass).Name + ";");
+
+            var files = FileBuilder.ParseFiles((ILogger)null, this.GetType().Assembly,
+                new Tuple<string, string>("topfile.sbs", f1.ToString()),
+                new Tuple<string, string>("lib3file.sbs", f2.ToString()),
+                new Tuple<string, string>("lib2file.sbs", f3.ToString()),
+                new Tuple<string, string>("lib1file.sbs", f4.ToString()));
+            Assert.AreEqual(4, files.Length);
+            Assert.AreEqual("topfile.sbs", files[0].FileName);
+            Assert.AreEqual("lib3file.sbs", files[1].FileName);
+            Assert.AreEqual("lib2file.sbs", files[2].FileName);
+            Assert.AreEqual("lib1file.sbs", files[3].FileName);
+            Assert.AreEqual(0, files[0].Errors.ErrorCount);
+            Assert.AreEqual(0, files[1].Errors.ErrorCount);
+            Assert.AreEqual(0, files[2].Errors.ErrorCount);
+            Assert.AreEqual(0, files[3].Errors.ErrorCount);
+            var procedureTop = files[0].ListElements().First(p => p.Name == "TopGetValue") as IFileProcedure;
+            Assert.IsNotNull(procedureTop);
+            var tool = files[0].ListElements().First(p => p.Name == "myTool");
+            Assert.IsNotNull(tool);
+
+            var taskContext = ExecutionHelper.ExeContext(services: FileBuilder.LastServiceManager.Manager);
+
+            var result = taskContext.CallProcedure(procedureTop);
+            Assert.AreEqual(91L, result);
         }
 
         [TestMethod]
         public void FileParsing_TypeDefGeneric()
         {
             var f1 = new StringBuilder();
-            f1.AppendLine("using " + typeof(DummyInstrumentClass).Namespace + ";");  // An object with the IResettable interface.
-            f1.AppendLine("using \"libfile.sbs\";");
-            f1.AppendLine("namespace TypedefTest;");
-            f1.AppendLine("procedure int TopGetValue() { return 8; }");
-
-            var f2 = new StringBuilder();
-            f2.AppendLine("using " + typeof(DummyInstrumentClass).Namespace + ";");  // An object with the IResettable interface.
-            f2.AppendLine("namespace TypedefTest;");
-            f2.AppendLine("typedef StringList System.Tuple<string>;");
-            //f2.AppendLine("typedef StringListStack Stack<List<string>>;");
-            //f2.AppendLine("public typedef MyTuple Tuple<int, bool, Verdict, Tuple<string,string>>;");
+            f1.AppendLine("typedef StringList System.Collections.Generic.List<string>;");
+            f1.AppendLine("procedure string MyProc() { ");
+            f1.AppendLine("    StringList list;");
+            f1.AppendLine("    list.Add(\"Anders\");");
+            f1.AppendLine("    list.Add(\"Bent\");");
+            f1.AppendLine("    list.Add(\"Christian\");");
+            f1.AppendLine("    return list[1];");
+            f1.AppendLine("}");
 
             var files = FileBuilder.ParseFiles((ILogger)null, this.GetType().Assembly,
-                new Tuple<string, string>("topfile.sbs", f1.ToString()),
-                new Tuple<string, string>("libfile.sbs", f2.ToString()));
-            Assert.AreEqual(2, files.Length);
+                new Tuple<string, string>("topfile.sbs", f1.ToString()));
+            Assert.AreEqual(1, files.Length);
             Assert.AreEqual("topfile.sbs", files[0].FileName);
-            Assert.AreEqual("libfile.sbs", files[1].FileName);
             Assert.AreEqual(0, files[0].Errors.ErrorCount);
-            Assert.AreEqual(0, files[1].Errors.ErrorCount);
-            var procedureTop = files[0].ListElements().First(p => p.Name == "TopGetValue") as IFileProcedure;
-            Assert.IsNotNull(procedureTop);
-            var element = files[1].ListElements().First(p => p.Name == "myTool") as IFileElement;
-            Assert.IsNotNull(element);
+            var proc = files[0].ListElements().First(p => p.Name == "MyProc") as IFileProcedure;
+            Assert.IsNotNull(proc);
 
             var taskContext = ExecutionHelper.ExeContext(services: FileBuilder.LastServiceManager.Manager);
 
-            var result = taskContext.CallProcedure(procedureTop);
-            Assert.AreEqual(72L, result);
+            var result = taskContext.CallProcedure(proc);
+            Assert.AreEqual("Bente", result);
         }
     }
 }

--- a/source/Test/StepBro.Core.Test/Parser/TestFileTypeScan.cs
+++ b/source/Test/StepBro.Core.Test/Parser/TestFileTypeScan.cs
@@ -246,21 +246,35 @@ namespace StepBroCoreTest.Parser
         [TestMethod]
         public void TestFileScanTypedefs()
         {
-            var result = FileBuilder.TypeScanFile("typedef StringList List<string>; typedef MyType TheBaseType;");
+            // Typedef for .net generic type.
+            var result = FileBuilder.TypeScanFile("typedef MyType TheBaseType;");
             Assert.AreEqual(FET.Namespace, result.TopElement.Type);
             Assert.AreEqual("Angus", result.TopElement.Name);
 
             var top = result.TopElement;
-            Assert.AreEqual(2, top.Childs.Count);
+            Assert.AreEqual(1, top.Childs.Count);
 
-            Assert.AreEqual(FET.TypeDef, top.Childs[0].Type);
-            Assert.AreEqual("StringList", top.Childs[0].Name);
-            Assert.AreEqual("List", top.Childs[0].DataType.GetGenericType().Item1);
-            Assert.AreEqual(1, top.Childs[0].DataType.ParameterCount);
-            Assert.AreEqual("string", top.Childs[0].DataType.GetParameter(0).GetGenericType().Item1);
-            
-            Assert.AreEqual("MyType", top.Childs[1].Name);
-            Assert.AreEqual("TheBaseType", top.Childs[1].DataType.GetGenericType().Item1);
+            var child = top.Childs[0];
+            Assert.AreEqual("MyType", child.Name);
+            Assert.AreEqual("TheBaseType", child.DataType.GetGenericType().Item1);
+
+
+            // Typedef for .net generic type.
+            result = FileBuilder.TypeScanFile("typedef StringList List<string>;");
+            Assert.AreEqual(FET.Namespace, result.TopElement.Type);
+            Assert.AreEqual("Angus", result.TopElement.Name);
+
+            top = result.TopElement;
+            Assert.AreEqual(1, top.Childs.Count);
+
+            child = top.Childs[0];
+            Assert.AreEqual(FET.TypeDef, child.Type);
+            Assert.AreEqual("StringList", child.Name);
+            Assert.AreEqual("List", child.DataType.GetGenericType().Item1);
+            Assert.AreEqual(1, child.DataType.ParameterCount);
+            Assert.AreEqual("string", child.DataType.GetParameter(0).GetGenericType().Item1);
+
+
         }
     }
 }

--- a/source/Test/StepBro.Core.Test/Parser/TestFileTypeScan.cs
+++ b/source/Test/StepBro.Core.Test/Parser/TestFileTypeScan.cs
@@ -242,5 +242,25 @@ namespace StepBroCoreTest.Parser
             Assert.AreEqual(0, result.TopElement.Childs[0].Parameters.Count);
             Assert.AreEqual("void", result.TopElement.Childs[0].ReturnType);
         }
+
+        [TestMethod]
+        public void TestFileScanTypedefs()
+        {
+            var result = FileBuilder.TypeScanFile("typedef StringList List<string>; typedef MyType TheBaseType;");
+            Assert.AreEqual(FET.Namespace, result.TopElement.Type);
+            Assert.AreEqual("Angus", result.TopElement.Name);
+
+            var top = result.TopElement;
+            Assert.AreEqual(2, top.Childs.Count);
+
+            Assert.AreEqual(FET.TypeDef, top.Childs[0].Type);
+            Assert.AreEqual("StringList", top.Childs[0].Name);
+            Assert.AreEqual("List", top.Childs[0].DataType.GetGenericType().Item1);
+            Assert.AreEqual(1, top.Childs[0].DataType.ParameterCount);
+            Assert.AreEqual("string", top.Childs[0].DataType.GetParameter(0).GetGenericType().Item1);
+            
+            Assert.AreEqual("MyType", top.Childs[1].Name);
+            Assert.AreEqual("TheBaseType", top.Childs[1].DataType.GetGenericType().Item1);
+        }
     }
 }

--- a/source/Test/StepBro.Core.Test/Parser/TestFileVariables.cs
+++ b/source/Test/StepBro.Core.Test/Parser/TestFileVariables.cs
@@ -230,5 +230,15 @@ namespace StepBroCoreTest.Parser
             m_resetCounts++;
             return true;
         }
+
+        public void DoSomething()
+        {
+            this.IntA += 1000;
+        }
+
+        public void DoSomethingElse()
+        {
+            this.IntA /= 4;
+        }
     }
 }

--- a/source/Test/StepBro.Core.Test/TestHostApplicationActionQueue.cs
+++ b/source/Test/StepBro.Core.Test/TestHostApplicationActionQueue.cs
@@ -62,7 +62,7 @@ namespace StepBroCoreTest
                 queue.AddTask("TaskAdd17", true, null, this.TaskAdd17);
             }
             var taskEnd = queue.AddTask("TaskNOP", true, null, this.TaskNOP);
-            Assert.IsTrue(taskEnd.Wait(TimeSpan.FromSeconds(2)));
+            Assert.IsTrue(taskEnd.Wait(TimeSpan.FromSeconds(5)));
             Assert.AreEqual(3400, m_testVariable);
             tasksFinished = queue.FinishedTasks - tasksFinished;
             Assert.AreEqual(201U, tasksFinished);

--- a/source/stepbro/Program.cs
+++ b/source/stepbro/Program.cs
@@ -41,6 +41,7 @@ namespace StepBro.Cmd
             {
                 if (!String.IsNullOrWhiteSpace(line)) ConsoleWriteLine(line);
             }
+            if (m_commandLineOptions.ReturnValueFromSubVerdict) m_commandLineOptions.ReturnValueFromVerdict = true;
             if (m_commandLineOptions.Verbose || args.Length == 0)
             {
                 ConsoleWriteLine("StepBro console application. Type 'stepbro --help' to show the help text.");
@@ -239,6 +240,24 @@ namespace StepBro.Cmd
                                                     else
                                                     {
                                                         ConsoleWriteLine("Procedure execution ended.");
+                                                    }
+                                                }
+
+                                                if (m_commandLineOptions.ReturnValueFromVerdict)
+                                                {
+                                                    switch (result.ProcedureResult.Verdict)
+                                                    {
+                                                        case Verdict.Unset:
+                                                        case Verdict.Pass:
+                                                            break;
+                                                        case Verdict.Inconclusive:
+                                                        case Verdict.Fail:
+                                                        case Verdict.Abandoned:
+                                                            retval = 1;
+                                                            break;
+                                                        case Verdict.Error:
+                                                            retval = -1;
+                                                            break;
                                                     }
                                                 }
                                             }

--- a/source/stepbro/Program.cs
+++ b/source/stepbro/Program.cs
@@ -161,12 +161,12 @@ namespace StepBro.Cmd
                                                 {
                                                     if (m_commandLineOptions.ReturnValueFromSubVerdict)
                                                     {
-                                                        var verdict = Verdict.Unset;
-                                                        foreach (var sr in result.ProcedureResult.ListSubResults())
+                                                        var verdict = result.ProcedureResult.Verdict;                   // Include verdict from the partner procedure result.
+                                                        foreach (var sr in result.ProcedureResult.ListSubResults())     // Check verdict from each sub result.
                                                         {
                                                             if (sr.Verdict > verdict) verdict = sr.Verdict;
                                                         }
-                                                         switch (verdict)
+                                                        switch (verdict)
                                                         {
                                                             case Verdict.Unset:
                                                             case Verdict.Pass:


### PR DESCRIPTION
Make basic 'typedef' functionality for both simple 'specialization' of existing types and to add usage of generic .net data types in scripts.