### PR TITLE
88 continue does not work in loops

### DIFF
--- a/source/StepBro.Core/Parser/StepBroListener.Procedure.cs
+++ b/source/StepBro.Core/Parser/StepBroListener.Procedure.cs
@@ -542,11 +542,13 @@ namespace StepBro.Core.Parser
             }
 
             var breakLabel = Expression.Label();
+            var continueLabel = Expression.Label();
 
             var isBlockSub = (subStatements[0].Type == ProcedureParsingScope.ScopeType.Block);
             if (isBlockSub)
             {
                 breakLabel = forLoopScope.BreakLabel;
+                continueLabel = forLoopScope.ContinueLabel;
             }
 
             var statementExpressions = new List<Expression>();
@@ -673,7 +675,7 @@ namespace StepBro.Core.Parser
                     Expression.Loop(
                         Expression.Block(loopExpressions),
                         breakLabel,
-                        subStatements[0].ContinueLabel));
+                        continueLabel));
             }
             else // Only a single statement without {} around
             {
@@ -685,7 +687,8 @@ namespace StepBro.Core.Parser
                 statementExpressions.Add(
                     Expression.Loop(
                         Expression.Block(loopExpressions),
-                        breakLabel));
+                        breakLabel,
+                        continueLabel));
             }
 
             List<ProcedureVariable> forVariables = forOuterScope.GetVariables();
@@ -735,11 +738,13 @@ namespace StepBro.Core.Parser
             }
 
             var breakLabel = Expression.Label();
+            var continueLabel = Expression.Label();
 
             var isBlockSub = (subStatements[0].Type == ProcedureParsingScope.ScopeType.Block);
             if (isBlockSub)
             {
                 breakLabel = whileScope.BreakLabel;
+                continueLabel = whileScope.ContinueLabel;
             }
 
             var statementExpressions = new List<Expression>();
@@ -846,7 +851,7 @@ namespace StepBro.Core.Parser
                     Expression.Loop(
                         subStatements[0].GetBlockCode(loopExpressions, null),
                         breakLabel,
-                        subStatements[0].ContinueLabel));
+                        continueLabel));
             }
             else
             {
@@ -854,7 +859,8 @@ namespace StepBro.Core.Parser
                 statementExpressions.Add(
                     Expression.Loop(
                         Expression.Block(loopExpressions),
-                        breakLabel));
+                        breakLabel,
+                        continueLabel));
             }
 
             m_scopeStack.Peek().AddStatementCode(statementExpressions.ToArray());

--- a/source/StepBro.Core/Parser/StepBroListener.Procedure.cs
+++ b/source/StepBro.Core/Parser/StepBroListener.Procedure.cs
@@ -40,7 +40,6 @@ namespace StepBro.Core.Parser
         private Stack<Stack<SBExpressionData>> m_statementExpressions = new Stack<Stack<SBExpressionData>>();
         private Stack<List<Expression>> m_forInitVariables = new Stack<List<Expression>>();
         private Stack<SBExpressionData> m_forCondition = new Stack<SBExpressionData>();
-        private Stack<Stack<SBExpressionData>> m_forUpdateExpressions = new Stack<Stack<SBExpressionData>>();
         //private Stack<TSExpressionData> m_keywordArguments = null;
 
         public Stack<SBExpressionData> GetArguments()
@@ -502,11 +501,6 @@ namespace StepBro.Core.Parser
             m_expressionData.PushStackLevel("for-update");
         }
 
-        public override void ExitForUpdate([NotNull] SBP.ForUpdateContext context)
-        {
-            m_forUpdateExpressions.Push(m_expressionData.PopStackLevel());
-        }
-
         public override void ExitForStatement([NotNull] SBP.ForStatementContext context)
         {
             var forLoopScope = m_scopeStack.Pop();
@@ -515,11 +509,7 @@ namespace StepBro.Core.Parser
             var forInitVariables = m_forInitVariables.Pop();
 
             // Contains the expressions in the for-update part of the for-loop
-            var forUpdateExpressions = new Stack<SBExpressionData>();
-            if (m_forUpdateExpressions.Count != 0)
-            {
-                forUpdateExpressions = m_forUpdateExpressions.Pop();
-            }
+            var forUpdateExpressions = m_expressionData.PopStackLevel();
             var forInitExpressions = m_expressionData.PopStackLevel();
 
             // Contains the part of the for-loop that contains the condition
@@ -676,37 +666,24 @@ namespace StepBro.Core.Parser
                 {
                     loopExpressions.Add(subStatementBlockCode);
                 }
-
-                // Add the continue label we jump to in case of a "continue" statement
-                // right before the for update expressions, so the for loop still updates
-                // when we write continue;
-                loopExpressions.Add(Expression.Label(continueLabel));
-                foreach (var expression in forUpdateExpressions)
-                {
-                    loopExpressions.Add(expression.ExpressionCode);
-                }
-                statementExpressions.Add(
-                    Expression.Loop(
-                        Expression.Block(loopExpressions),
-                        breakLabel));
             }
             else // Only a single statement without {} around
             {
                 loopExpressions.Add(subStatements[0].GetOnlyStatementCode());
-
-                // Add the continue label we jump to in case of a "continue" statement
-                // right before the for update expressions, so the for loop still updates
-                // when we write continue;
-                loopExpressions.Add(Expression.Label(continueLabel));
-                foreach (var expression in forUpdateExpressions)
-                {
-                    loopExpressions.Add(expression.ExpressionCode);
-                }
-                statementExpressions.Add(
-                    Expression.Loop(
-                        Expression.Block(loopExpressions),
-                        breakLabel));
             }
+
+            // Add the continue label we jump to in case of a "continue" statement
+            // right before the for update expressions, so the for loop still updates
+            // when we write continue;
+            loopExpressions.Add(Expression.Label(continueLabel));
+            foreach (var expression in forUpdateExpressions)
+            {
+                loopExpressions.Add(expression.ExpressionCode);
+            }
+            statementExpressions.Add(
+                Expression.Loop(
+                    Expression.Block(loopExpressions),
+                    breakLabel));
 
             List<ProcedureVariable> forVariables = forOuterScope.GetVariables();
             List<Expression> forLoopExpression = new List<Expression>();

--- a/source/Test/StepBro.Core.Test/Execution/TestProcedure_For.cs
+++ b/source/Test/StepBro.Core.Test/Execution/TestProcedure_For.cs
@@ -338,6 +338,39 @@ namespace StepBroCoreTest.Parser
         }
 
         [TestMethod]
+        public void TestProcedureForStatementWithBreak01()
+        {
+            var proc = FileBuilder.ParseProcedureExpectNoErrors(
+                """
+                int Func()
+                {
+                    var output = 0;
+                    
+                    for (var i = 0; i < 100; i += 35)
+                    {
+                        output += 12;
+
+                        if (output == 12)
+                        {
+                            output++;
+                            break;
+                        }
+
+                        output += 5;
+                    }
+
+                    return output;
+                }
+                """);
+            Assert.AreEqual(typeof(long), proc.ReturnType.Type);
+            Assert.AreEqual(0, proc.Parameters.Length);
+            object result = proc.Call();
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOfType(result, typeof(long));
+            Assert.AreEqual(13L, (long)result);
+        }
+
+        [TestMethod]
         public void TestProcedureForStatementWithinForStatement01()
         {
             var proc = FileBuilder.ParseProcedureExpectNoErrors(

--- a/source/Test/StepBro.Core.Test/Execution/TestProcedure_For.cs
+++ b/source/Test/StepBro.Core.Test/Execution/TestProcedure_For.cs
@@ -305,7 +305,6 @@ namespace StepBroCoreTest.Parser
         }
 
         [TestMethod]
-        [Ignore("Continue not implemented yet.")]
         public void TestProcedureForStatementWithContinue01()
         {
             var proc = FileBuilder.ParseProcedureExpectNoErrors(

--- a/source/Test/StepBro.Core.Test/Execution/TestProcedure_For.cs
+++ b/source/Test/StepBro.Core.Test/Execution/TestProcedure_For.cs
@@ -338,6 +338,39 @@ namespace StepBroCoreTest.Parser
         }
 
         [TestMethod]
+        public void TestProcedureForStatementWithContinue02()
+        {
+            var proc = FileBuilder.ParseProcedureExpectNoErrors(
+                """
+                int Func()
+                {
+                    var output = 0;
+                    
+                    for (var i = 0, var j = 0; i < 200; i += 35, j += 12)
+                    {
+                        output += 12;
+
+                        if (output == 12)
+                        {
+                            output++;
+                            continue;
+                        }
+
+                        output += j;
+                    }
+
+                    return output;
+                }
+                """);
+            Assert.AreEqual(typeof(long), proc.ReturnType.Type);
+            Assert.AreEqual(0, proc.Parameters.Length);
+            object result = proc.Call();
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOfType(result, typeof(long));
+            Assert.AreEqual(253L, (long)result);
+        }
+
+        [TestMethod]
         public void TestProcedureForStatementWithBreak01()
         {
             var proc = FileBuilder.ParseProcedureExpectNoErrors(

--- a/source/Test/StepBro.Core.Test/Execution/TestProcedure_While.cs
+++ b/source/Test/StepBro.Core.Test/Execution/TestProcedure_While.cs
@@ -231,19 +231,22 @@ namespace StepBroCoreTest.Parser
                 int Func()
                 {
                     int i = 0;
+                    int output = 0;
                     while (i < 1000)
                     {
                         int a = 5;
 
                         if (i == 200)
                         {
+                            output += 5;
                             i += 15;
                             continue;
                         }
 
+                        output += a;
                         i += a;
                     }
-                    return i;
+                    return output;
                 }
                 """);
             Assert.AreEqual(typeof(long), proc.ReturnType.Type);

--- a/source/Test/StepBro.Core.Test/Execution/TestProcedure_While.cs
+++ b/source/Test/StepBro.Core.Test/Execution/TestProcedure_While.cs
@@ -224,7 +224,6 @@ namespace StepBroCoreTest.Parser
         }
 
         [TestMethod]
-        [Ignore("Continue not implemented yet.")]
         public void TestProcedureWhileStatementContinue01()
         {
             var proc = FileBuilder.ParseProcedureExpectNoErrors(


### PR DESCRIPTION
Continue now works in loops.

With while loops it was simple, just adding the continue label to the loop expression.

With for loops we needed to add the continue label after the for statements, but before the for update statements, so we created a label with the same tag as the continue label in the for loop and added it the correct place.