### PR TITLE
89 Loop statement disappears if it is only statement inside another loop (without {})

### DIFF
--- a/source/StepBro.Core/Parser/StepBro.g4
+++ b/source/StepBro.Core/Parser/StepBro.g4
@@ -396,13 +396,13 @@ blockStatementAttributes : attributes ;
 subStatement : block | statement ;
 
 statement
-    :   (ASSERT | EXPECT) (REGULAR_STRING COLON)? parExpression SEMICOLON			# expectStatement
-    |   IF parExpression subStatement (ELSE subStatement)?							# ifStatement
-    |   FOR OPEN_PARENS forControl CLOSE_PARENS subStatement						# forStatement
-    |   FOREACH OPEN_PARENS foreachControl CLOSE_PARENS subStatement				# foreachStatement
-    |   WHILE parExpression ( COLON elementPropertyList )? subStatement	            # whileStatement
-    |   DO subStatement WHILE parExpression SEMICOLON								# doWhileStatement
-    |	USING OPEN_PARENS usingExpression CLOSE_PARENS subStatement					# usingStatement
+    :   (ASSERT | EXPECT) (REGULAR_STRING COLON)? parExpression SEMICOLON			        # expectStatement
+    |   IF parExpression subStatement (ELSE subStatement)?							        # ifStatement
+    |   FOR OPEN_PARENS forControl CLOSE_PARENS ( COLON elementPropertyList )? subStatement	# forStatement
+    |   FOREACH OPEN_PARENS foreachControl CLOSE_PARENS subStatement				        # foreachStatement
+    |   WHILE parExpression ( COLON elementPropertyList )? subStatement	                    # whileStatement
+    |   DO subStatement WHILE parExpression SEMICOLON								        # doWhileStatement
+    |	USING OPEN_PARENS usingExpression CLOSE_PARENS subStatement					        # usingStatement
     //|   'try' block
     //    ( catches 'finally' block
     //    | catches

--- a/source/Test/StepBro.Core.Test/Execution/TestProcedure_For.cs
+++ b/source/Test/StepBro.Core.Test/Execution/TestProcedure_For.cs
@@ -431,7 +431,6 @@ namespace StepBroCoreTest.Parser
         }
 
         [TestMethod]
-        [Ignore("When the only statement in a for loop is another for loop, it breaks. The substatement does not get created.")]
         public void TestProcedureForStatementWithinForStatement02()
         {
             var proc = FileBuilder.ParseProcedureExpectNoErrors(
@@ -479,6 +478,57 @@ namespace StepBroCoreTest.Parser
             Assert.IsNotNull(result);
             Assert.IsInstanceOfType(result, typeof(long));
             Assert.AreEqual(450L, (long)result);
+        }
+
+        [TestMethod]
+        public void TestProcedureForStatementWithTimeout01()
+        {
+            var proc = FileBuilder.ParseProcedureExpectNoErrors(
+                """
+                int Func()
+                {
+                    var output = 0;
+                    for (var i = 0; i < 5000000; i += 1) : 
+                        Timeout: 20ms
+                    {
+                        output++;
+                    }
+                    return output;
+                }
+                """);
+            Assert.AreEqual(typeof(long), proc.ReturnType.Type);
+            Assert.AreEqual(0, proc.Parameters.Length);
+            object result = proc.Call();
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOfType(result, typeof(long));
+            Assert.IsTrue((long)result < 5000000);
+            Assert.IsTrue((long)result > 1000);         // Just to check that the loop iterated several times
+        }
+
+        [TestMethod]
+        public void TestProcedureForStatementWithTimeout02()
+        {
+            var proc = FileBuilder.ParseProcedureExpectNoErrors(
+                """
+                int Func()
+                {
+                    var output = 0;
+                    var t = 20ms;
+                    for (var i = 0; i < 5000000; i += 1) : 
+                        Timeout: t
+                    {
+                        output++;
+                    }
+                    return output;
+                }
+                """);
+            Assert.AreEqual(typeof(long), proc.ReturnType.Type);
+            Assert.AreEqual(0, proc.Parameters.Length);
+            object result = proc.Call();
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOfType(result, typeof(long));
+            Assert.IsTrue((long)result < 5000000);
+            Assert.IsTrue((long)result > 1000);         // Just to check that the loop iterated several times
         }
     }
 }

--- a/source/Test/StepBro.Core.Test/Execution/TestProcedure_While.cs
+++ b/source/Test/StepBro.Core.Test/Execution/TestProcedure_While.cs
@@ -84,6 +84,25 @@ namespace StepBroCoreTest.Parser
         }
 
         [TestMethod]
+        public void TestProcedureWhileStatementWithTimeout02()
+        {
+            var proc = FileBuilder.ParseProcedureExpectNoErrors(
+                "int Func(){ var n = 0; " +
+                "while (n < 5000000) :" +
+                "    Timeout: 20ms" +
+                "{ n++; }" +        // ENSURE THIS TAKES MORE THAN 20ms !!
+                "return n; }");
+            Assert.AreEqual(typeof(long), proc.ReturnType.Type);
+            Assert.AreEqual(0, proc.Parameters.Length);
+
+            object result = proc.Call();
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOfType(result, typeof(long));
+            Assert.IsTrue((long)result < 5000000);
+            Assert.IsTrue((long)result > 1000);         // Just to check that the loop iterated several times
+        }
+
+        [TestMethod]
         public void TestProcedureWhileStatementWithTimeoutFromVariable()
         {
             var proc = FileBuilder.ParseProcedureExpectNoErrors(
@@ -92,6 +111,26 @@ namespace StepBroCoreTest.Parser
                 "while (true) :" +
                 "    Timeout: t" +
                 "{ n++; if (n > 5000000) break; }" +        // ENSURE THIS TAKES MORE THAN 20ms !!
+                "return n; }");
+            Assert.AreEqual(typeof(long), proc.ReturnType.Type);
+            Assert.AreEqual(0, proc.Parameters.Length);
+
+            object result = proc.Call();
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOfType(result, typeof(long));
+            Assert.IsTrue((long)result < 5000000);
+            Assert.IsTrue((long)result > 1000);         // Just to check that the loop iterated several times
+        }
+
+        [TestMethod]
+        public void TestProcedureWhileStatementWithTimeoutFromVariable02()
+        {
+            var proc = FileBuilder.ParseProcedureExpectNoErrors(
+                "int Func(){ var n = 0; " +
+                "var t = 20ms; " +
+                "while (n < 5000000) :" +
+                "    Timeout: t" +
+                "{ n++; }" +        // ENSURE THIS TAKES MORE THAN 20ms !!
                 "return n; }");
             Assert.AreEqual(typeof(long), proc.ReturnType.Type);
             Assert.AreEqual(0, proc.Parameters.Length);
@@ -258,7 +297,6 @@ namespace StepBroCoreTest.Parser
         }
 
         [TestMethod]
-        [Ignore("When the only statement in a loop is another loop, it breaks unless it has {}. The substatement does not get created.")]
         public void TestProcedureWhileStatementSingleStatementInWhileLoop01()
         {
             var proc = FileBuilder.ParseProcedureExpectNoErrors(


### PR DESCRIPTION
Furthermore, enhances for-loops so they can have timeouts