### PR TITLE
75 asynclogcurrenttimestampmillisecond does not seem to give an answer if we have just awaited the last log message

### DIFF
--- a/source/StepBro.Core/Data/ILineReader.cs
+++ b/source/StepBro.Core/Data/ILineReader.cs
@@ -16,7 +16,6 @@ namespace StepBro.Core.Data
         INameable Source { get; }
         object Sync { get; }
         ILineReaderEntry Current { get; }
-        ILineReaderEntry Previous { get; }
         bool LinesHaveTimestamp { get; }
         bool HasMore { get; }
         bool Next();

--- a/source/StepBro.Core/Data/ILineReader.cs
+++ b/source/StepBro.Core/Data/ILineReader.cs
@@ -19,6 +19,7 @@ namespace StepBro.Core.Data
         bool LinesHaveTimestamp { get; }
         bool HasMore { get; }
         bool Next();
+        bool NextUnlessNewEntry();
         void Flush(ILineReaderEntry stopAt = null);
         IEnumerable<ILineReaderEntry> Peak();
         event EventHandler LinesAdded;

--- a/source/StepBro.Core/Data/ILineReader.cs
+++ b/source/StepBro.Core/Data/ILineReader.cs
@@ -16,6 +16,7 @@ namespace StepBro.Core.Data
         INameable Source { get; }
         object Sync { get; }
         ILineReaderEntry Current { get; }
+        ILineReaderEntry Previous { get; }
         bool LinesHaveTimestamp { get; }
         bool HasMore { get; }
         bool Next();

--- a/source/StepBro.Core/Data/LineReaders.cs
+++ b/source/StepBro.Core/Data/LineReaders.cs
@@ -20,7 +20,6 @@ namespace StepBro.Core.Data
         private readonly List<string> m_list;
         private int m_index;
         private EntryWrapper m_current;
-        private EntryWrapper m_previous;
 
         public StringListLineReader(List<string> list, INameable source = null)
         {
@@ -43,7 +42,6 @@ namespace StepBro.Core.Data
                 return m_current;
             }
         }
-
         public bool LinesHaveTimestamp { get { return false; } }
 
         public bool HasMore { get { return (m_index < (m_list.Count - 1)); } }

--- a/source/StepBro.Core/Data/LineReaders.cs
+++ b/source/StepBro.Core/Data/LineReaders.cs
@@ -44,17 +44,6 @@ namespace StepBro.Core.Data
             }
         }
 
-        public ILineReaderEntry Previous 
-        { 
-            get 
-            {
-                if (m_index > 0 && m_index - 1 < m_list.Count && m_list.Count > 0) m_previous = new EntryWrapper(m_index - 1, m_list[m_index - 1]);
-                else m_previous = null;
-
-                return m_previous;
-            } 
-        }
-
         public bool LinesHaveTimestamp { get { return false; } }
 
         public bool HasMore { get { return (m_index < (m_list.Count - 1)); } }

--- a/source/StepBro.Core/Data/LineReaders.cs
+++ b/source/StepBro.Core/Data/LineReaders.cs
@@ -42,6 +42,9 @@ namespace StepBro.Core.Data
                 return m_current;
             }
         }
+
+        public ILineReaderEntry Previous { get { throw new NotImplementedException("StringListLineReader does not have the Previous element implemented."); } }
+
         public bool LinesHaveTimestamp { get { return false; } }
 
         public bool HasMore { get { return (m_index < (m_list.Count - 1)); } }

--- a/source/StepBro.Core/Data/LineReaders.cs
+++ b/source/StepBro.Core/Data/LineReaders.cs
@@ -20,6 +20,7 @@ namespace StepBro.Core.Data
         private readonly List<string> m_list;
         private int m_index;
         private EntryWrapper m_current;
+        private EntryWrapper m_previous;
 
         public StringListLineReader(List<string> list, INameable source = null)
         {
@@ -43,7 +44,16 @@ namespace StepBro.Core.Data
             }
         }
 
-        public ILineReaderEntry Previous { get { throw new NotImplementedException("StringListLineReader does not have the Previous element implemented."); } }
+        public ILineReaderEntry Previous 
+        { 
+            get 
+            {
+                if (m_index > 0 && m_index - 1 < m_list.Count && m_list.Count > 0) m_previous = new EntryWrapper(m_index - 1, m_list[m_index - 1]);
+                else m_previous = null;
+
+                return m_previous;
+            } 
+        }
 
         public bool LinesHaveTimestamp { get { return false; } }
 

--- a/source/StepBro.Core/Data/LineReaders.cs
+++ b/source/StepBro.Core/Data/LineReaders.cs
@@ -78,6 +78,11 @@ namespace StepBro.Core.Data
             return false;
         }
 
+        public bool NextUnlessNewEntry()
+        {
+            return Next(); // Next works the same as NextUnlessNewEntry for this line reader
+        }
+
         public IEnumerable<ILineReaderEntry> Peak()
         {
             if (m_index < m_list.Count)

--- a/source/StepBro.Core/Data/LineReaders.cs
+++ b/source/StepBro.Core/Data/LineReaders.cs
@@ -20,13 +20,13 @@ namespace StepBro.Core.Data
         private readonly List<string> m_list;
         private int m_index;
         private EntryWrapper m_current;
-        private bool m_nextEntryIsNew = true;
+        private bool m_currentEntryIsNew = true;
 
         public StringListLineReader(List<string> list, INameable source = null)
         {
             m_list = list;
             m_index = (m_list.Count > 0) ? 0 : -1;
-            m_nextEntryIsNew = true;
+            m_currentEntryIsNew = true;
             this.Source = source;
         }
 
@@ -76,17 +76,17 @@ namespace StepBro.Core.Data
             else if (m_index < (m_list.Count))
             {
                 m_index++;  // Skip past the last entry
-                m_nextEntryIsNew = true;
+                m_currentEntryIsNew = true;
             }
             return false;
         }
 
         public bool NextUnlessNewEntry()
         {
-            if (!m_nextEntryIsNew)
+            if (!m_currentEntryIsNew)
                 return Next();
             else if (m_index < (m_list.Count - 1) || m_index == 0)
-                m_nextEntryIsNew = false;
+                m_currentEntryIsNew = false;
             return false;
         }
 

--- a/source/StepBro.Core/Data/LineReaders.cs
+++ b/source/StepBro.Core/Data/LineReaders.cs
@@ -20,13 +20,13 @@ namespace StepBro.Core.Data
         private readonly List<string> m_list;
         private int m_index;
         private EntryWrapper m_current;
-        private bool m_first = true;
+        private bool m_nextEntryIsNew = true;
 
         public StringListLineReader(List<string> list, INameable source = null)
         {
             m_list = list;
             m_index = (m_list.Count > 0) ? 0 : -1;
-            m_first = true;
+            m_nextEntryIsNew = true;
             this.Source = source;
         }
 
@@ -76,16 +76,17 @@ namespace StepBro.Core.Data
             else if (m_index < (m_list.Count))
             {
                 m_index++;  // Skip past the last entry
+                m_nextEntryIsNew = true;
             }
             return false;
         }
 
         public bool NextUnlessNewEntry()
         {
-            if (!m_first)
-                return Next(); // Next works the same as NextUnlessNewEntry for this line reader - Except for the very first
-            else
-                m_first = false;
+            if (!m_nextEntryIsNew)
+                return Next();
+            else if (m_index < (m_list.Count - 1) || m_index == 0)
+                m_nextEntryIsNew = false;
             return false;
         }
 

--- a/source/StepBro.Core/Data/LineReaders.cs
+++ b/source/StepBro.Core/Data/LineReaders.cs
@@ -20,11 +20,13 @@ namespace StepBro.Core.Data
         private readonly List<string> m_list;
         private int m_index;
         private EntryWrapper m_current;
+        private bool m_first = true;
 
         public StringListLineReader(List<string> list, INameable source = null)
         {
             m_list = list;
             m_index = (m_list.Count > 0) ? 0 : -1;
+            m_first = true;
             this.Source = source;
         }
 
@@ -80,7 +82,11 @@ namespace StepBro.Core.Data
 
         public bool NextUnlessNewEntry()
         {
-            return Next(); // Next works the same as NextUnlessNewEntry for this line reader
+            if (!m_first)
+                return Next(); // Next works the same as NextUnlessNewEntry for this line reader - Except for the very first
+            else
+                m_first = false;
+            return false;
         }
 
         public IEnumerable<ILineReaderEntry> Peak()

--- a/source/StepBro.Core/Data/LogLineLineReader.cs
+++ b/source/StepBro.Core/Data/LogLineLineReader.cs
@@ -79,7 +79,6 @@ namespace StepBro.Core.Data
 
         private object m_sync;
         private LogLineData m_entry = null;
-        private LogLineData m_previousEntry = null;
 
         public event EventHandler LinesAdded;
 
@@ -88,7 +87,6 @@ namespace StepBro.Core.Data
             this.Source = source;
             m_sync = sync;
             m_entry = first;
-            m_previousEntry = null;
         }
 
         public void NotifyNew(LogLineData entry)
@@ -119,8 +117,6 @@ namespace StepBro.Core.Data
 
         public ILineReaderEntry Current { get { return m_entry; } }
 
-        public ILineReaderEntry Previous { get { return m_previousEntry; } }
-
         public INameable Source { get; private set; }
 
         public bool Next()
@@ -129,7 +125,6 @@ namespace StepBro.Core.Data
             {
                 if (m_entry != null)
                 {
-                    m_previousEntry = m_entry;
                     m_entry = m_entry.Next;
                     return true;
                 }
@@ -143,7 +138,6 @@ namespace StepBro.Core.Data
             {
                 lock (m_sync)
                 {
-                    m_previousEntry = null;
                     m_entry = (LogLineData)stopAt;
                 }
             }
@@ -151,7 +145,6 @@ namespace StepBro.Core.Data
             {
                 lock (m_sync)
                 {
-                    m_previousEntry = null;
                     m_entry = null;
                 }
             }

--- a/source/StepBro.Core/Data/LogLineLineReader.cs
+++ b/source/StepBro.Core/Data/LogLineLineReader.cs
@@ -78,6 +78,7 @@ namespace StepBro.Core.Data
         }
 
         private object m_sync;
+        private bool m_newEntry = true;
         private LogLineData m_entry = null;
 
         public event EventHandler LinesAdded;
@@ -87,6 +88,7 @@ namespace StepBro.Core.Data
             this.Source = source;
             m_sync = sync;
             m_entry = first;
+            m_newEntry = true;
         }
 
         public void NotifyNew(LogLineData entry)
@@ -96,6 +98,7 @@ namespace StepBro.Core.Data
                 if (m_entry == null)
                 {
                     m_entry = entry;
+                    m_newEntry = true;
                     Monitor.Pulse(m_sync);  // In case someone is waiting.
                 }
                 this.LinesAdded?.Invoke(this, EventArgs.Empty);
@@ -129,6 +132,23 @@ namespace StepBro.Core.Data
                     return true;
                 }
                 else return false;
+            }
+        }
+
+        public bool NextUnlessNewEntry()
+        {
+            lock (m_sync)
+            {
+                if (!m_newEntry && m_entry != null)
+                {
+                    m_entry = m_entry.Next;
+                    return true;
+                }
+                else
+                {
+                    m_newEntry = false;
+                }
+                return false;
             }
         }
 

--- a/source/StepBro.Core/Data/LogLineLineReader.cs
+++ b/source/StepBro.Core/Data/LogLineLineReader.cs
@@ -79,6 +79,7 @@ namespace StepBro.Core.Data
 
         private object m_sync;
         private LogLineData m_entry = null;
+        private LogLineData m_previousEntry = null;
 
         public event EventHandler LinesAdded;
 
@@ -87,6 +88,7 @@ namespace StepBro.Core.Data
             this.Source = source;
             m_sync = sync;
             m_entry = first;
+            m_previousEntry = null;
         }
 
         public void NotifyNew(LogLineData entry)
@@ -117,6 +119,8 @@ namespace StepBro.Core.Data
 
         public ILineReaderEntry Current { get { return m_entry; } }
 
+        public ILineReaderEntry Previous { get { return m_previousEntry; } }
+
         public INameable Source { get; private set; }
 
         public bool Next()
@@ -125,6 +129,7 @@ namespace StepBro.Core.Data
             {
                 if (m_entry != null)
                 {
+                    m_previousEntry = m_entry;
                     m_entry = m_entry.Next;
                     return true;
                 }
@@ -138,6 +143,7 @@ namespace StepBro.Core.Data
             {
                 lock (m_sync)
                 {
+                    m_previousEntry = null;
                     m_entry = (LogLineData)stopAt;
                 }
             }
@@ -145,6 +151,7 @@ namespace StepBro.Core.Data
             {
                 lock (m_sync)
                 {
+                    m_previousEntry = null;
                     m_entry = null;
                 }
             }

--- a/source/StepBro.Core/Data/LogLineLineReader.cs
+++ b/source/StepBro.Core/Data/LogLineLineReader.cs
@@ -78,7 +78,7 @@ namespace StepBro.Core.Data
         }
 
         private object m_sync;
-        private bool m_newEntry = true;
+        private bool m_firstEntryIsNew = true;
         private LogLineData m_entry = null;
 
         public event EventHandler LinesAdded;
@@ -88,7 +88,7 @@ namespace StepBro.Core.Data
             this.Source = source;
             m_sync = sync;
             m_entry = first;
-            m_newEntry = true;
+            m_firstEntryIsNew = true;
         }
 
         public void NotifyNew(LogLineData entry)
@@ -98,7 +98,7 @@ namespace StepBro.Core.Data
                 if (m_entry == null)
                 {
                     m_entry = entry;
-                    m_newEntry = true;
+                    m_firstEntryIsNew = true;
                     Monitor.Pulse(m_sync);  // In case someone is waiting.
                 }
                 this.LinesAdded?.Invoke(this, EventArgs.Empty);
@@ -139,14 +139,14 @@ namespace StepBro.Core.Data
         {
             lock (m_sync)
             {
-                if (!m_newEntry && m_entry != null)
+                if (!m_firstEntryIsNew && m_entry != null)
                 {
                     m_entry = m_entry.Next;
                     return true;
                 }
                 else
                 {
-                    m_newEntry = false;
+                    m_firstEntryIsNew = false;
                 }
                 return false;
             }

--- a/source/StepBro.Core/Execution/ScriptUtils.cs
+++ b/source/StepBro.Core/Execution/ScriptUtils.cs
@@ -267,6 +267,9 @@ namespace StepBro.Core.Execution
             {
                 // If there isn't anything in the reader right now
                 // we wait 5ms to see if anything shows up
+                // The OS has a hard time keeping up with anything less than 5ms
+                // anyway, as we need to get chosen as a thread again after the
+                // timeout. Because of this, any awaits should be longer than 5ms anyway.
                 lock (reader.Sync)
                 {
                     if (reader.Current == null)

--- a/source/StepBro.Core/Execution/ScriptUtils.cs
+++ b/source/StepBro.Core/Execution/ScriptUtils.cs
@@ -281,24 +281,35 @@ namespace StepBro.Core.Execution
                 // If the string was found
                 if (result != null)
                 {
-
-                    // We take the timestamp of the found string
-                    DateTime foundTimeStamp = reader.Current.Timestamp;
-
-                    if (removeFound)
+                    if (reader.LinesHaveTimestamp)
                     {
-                        reader.Next();
-                    }
+                        // We take the timestamp of the found string
+                        DateTime foundTimeStamp = reader.Current.Timestamp;
 
-                    // We check if the time stamp is within the allowed time
-                    if (foundTimeStamp <= to)
-                    {
-                        return result;
+                        if (removeFound)
+                        {
+                            reader.Next();
+                        }
+
+                        // We check if the time stamp is within the allowed time
+                        if (foundTimeStamp <= to)
+                        {
+                            return result;
+                        }
                     }
                     else
                     {
-                        break;
+                        if (removeFound)
+                        {
+                            reader.Next();
+                        }
+
+                        if (DateTime.Now.TimeTill(to) > TimeSpan.Zero)
+                        {
+                            return result;
+                        }
                     }
+                    break;
                 }
             } while (DateTime.Now.TimeTill(to) > TimeSpan.Zero); // We use DateTime.Now because we can not be sure that anything is in the log to give us a timestamp
 

--- a/source/StepBro.Core/Execution/ScriptUtils.cs
+++ b/source/StepBro.Core/Execution/ScriptUtils.cs
@@ -243,12 +243,18 @@ namespace StepBro.Core.Execution
         }
 
         [Public]
-        public static string Await(this ILineReader reader, [Implicit] ICallContext context, string text, TimeSpan timeout, bool removeFound = true)
+        public static string Await(this ILineReader reader, [Implicit] ICallContext context, string text, TimeSpan timeout, bool skipCurrent = true, bool removeFound = false)
         {
             System.Diagnostics.Debug.WriteLine("Reader.Await: " + text);
             if (context != null && context.LoggingEnabled) context.Logger.Log("Await \"" + text + "\"");
             var comparer = StringUtils.CreateComparer(text);
             reader.DebugDump();
+
+            // If we do not want to match with the current entry
+            if(skipCurrent)
+            {
+                reader.NextUnlessNewEntry();
+            }
 
             // If the reader has timestamp, set the timeout relative to the time of the current entry; otherwise just use current wall time.
             DateTime entry = (reader.LinesHaveTimestamp && reader.Current != null) ? reader.Current.Timestamp : DateTime.Now;

--- a/source/StepBro.Core/Execution/ScriptUtils.cs
+++ b/source/StepBro.Core/Execution/ScriptUtils.cs
@@ -266,12 +266,12 @@ namespace StepBro.Core.Execution
             do
             {
                 // If there isn't anything in the reader right now
-                // we wait 50ms to see if anything shows up
+                // we wait 5ms to see if anything shows up
                 lock (reader.Sync)
                 {
                     if (reader.Current == null)
                     {
-                        Monitor.Wait(reader.Sync, 50);
+                        Monitor.Wait(reader.Sync, 5);
                     }
                 }
 


### PR DESCRIPTION
Makes Current point to the expected log

Fixes an issue where we could fail even if a log came within the right time (in exceptionally rare circumstances)