### PR TITLE
1 int64tryparse does not seem to work

### DIFF
--- a/source/StepBro.Core/Parser/StepBroListener.ExpressionMethodCall.cs
+++ b/source/StepBro.Core/Parser/StepBroListener.ExpressionMethodCall.cs
@@ -920,6 +920,11 @@ namespace StepBro.Core.Parser
                                 continue;
                             }
                         }
+                        else if (argPicker.Current.Argument == "out")
+                        {
+                            suggestedAssignmentsOut.Add(argPicker.Pick());
+                            continue;
+                        }
                         else
                         {
                             // TODO: Report argument not found, maybe

--- a/source/Test/StepBro.Core.Test/Parser/Expression/TestMethodCall.cs
+++ b/source/Test/StepBro.Core.Test/Parser/Expression/TestMethodCall.cs
@@ -301,7 +301,7 @@ namespace StepBroCoreTest.Parser
         }
 
         [TestMethod]
-        public void TestOutVariableInt()
+        public void TestOutVariableIntSuccess()
         {
             var proc = FileBuilder.ParseProcedureExpectNoErrors(
                 """
@@ -329,6 +329,46 @@ namespace StepBroCoreTest.Parser
                 {
                     int a = 0;
                     bool success = Int64.TryParse("abc", out a);
+                    return success;
+                }
+                """);
+            Assert.AreEqual(typeof(bool), proc.ReturnType.Type);
+            Assert.AreEqual(0, proc.Parameters.Length);
+            object result = proc.Call();
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOfType(result, typeof(bool));
+            Assert.AreEqual(false, (bool)result);
+        }
+
+        [TestMethod]
+        public void TestOutVariableBoolSuccess()
+        {
+            var proc = FileBuilder.ParseProcedureExpectNoErrors(
+                """
+                bool Func()
+                {
+                    bool a = false;
+                    bool success = Boolean.TryParse("true", out a);
+                    return a;
+                }
+                """);
+            Assert.AreEqual(typeof(bool), proc.ReturnType.Type);
+            Assert.AreEqual(0, proc.Parameters.Length);
+            object result = proc.Call();
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOfType(result, typeof(bool));
+            Assert.AreEqual(true, (bool)result);
+        }
+
+        [TestMethod]
+        public void TestOutVariableBoolFailure()
+        {
+            var proc = FileBuilder.ParseProcedureExpectNoErrors(
+                """
+                bool Func()
+                {
+                    bool a = false;
+                    bool success = Boolean.TryParse("123", out a);
                     return success;
                 }
                 """);

--- a/source/Test/StepBro.Core.Test/Parser/Expression/TestMethodCall.cs
+++ b/source/Test/StepBro.Core.Test/Parser/Expression/TestMethodCall.cs
@@ -299,5 +299,45 @@ namespace StepBroCoreTest.Parser
                 "var value = rnd.Next(0, 100);",
                 false));
         }
+
+        [TestMethod]
+        public void TestOutVariableInt()
+        {
+            var proc = FileBuilder.ParseProcedureExpectNoErrors(
+                """
+                int Func()
+                {
+                    int a = 0;
+                    bool success = Int64.TryParse("7", out a);
+                    return a;
+                }
+                """);
+            Assert.AreEqual(typeof(long), proc.ReturnType.Type);
+            Assert.AreEqual(0, proc.Parameters.Length);
+            object result = proc.Call();
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOfType(result, typeof(long));
+            Assert.AreEqual(7L, (long)result);
+        }
+
+        [TestMethod]
+        public void TestOutVariableIntFailure()
+        {
+            var proc = FileBuilder.ParseProcedureExpectNoErrors(
+                """
+                bool Func()
+                {
+                    int a = 0;
+                    bool success = Int64.TryParse("abc", out a);
+                    return success;
+                }
+                """);
+            Assert.AreEqual(typeof(bool), proc.ReturnType.Type);
+            Assert.AreEqual(0, proc.Parameters.Length);
+            object result = proc.Call();
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOfType(result, typeof(bool));
+            Assert.AreEqual(false, (bool)result);
+        }
     }
 }


### PR DESCRIPTION
Handle "out" arguments in ExpressionMethodCall.
Add tests for this.