### PR TITLE
Improve print report error message handling

### DIFF
--- a/source/StepBro.Core/Addons/OutputAzurePipelineFormatAddon.cs
+++ b/source/StepBro.Core/Addons/OutputAzurePipelineFormatAddon.cs
@@ -180,7 +180,7 @@ namespace StepBro.Core.Addons
                             m_writer.WriteLine("##[endgroup]");
                             m_writer.WriteLine("");     // Empty line
                         }
-                        else if (group.LogEnd == null)
+                        else if (group.LogEnd == null) // If group.LogEnd is null, a fatal error has occurred during execution
                         {
                             m_writer.WriteLine("##[error] An error has occurred. Dumping log.");
                             var entry = group.LogStart;

--- a/source/StepBro.Core/Addons/OutputAzurePipelineFormatAddon.cs
+++ b/source/StepBro.Core/Addons/OutputAzurePipelineFormatAddon.cs
@@ -162,7 +162,7 @@ namespace StepBro.Core.Addons
                         m_writer.WriteLine("##[endgroup]");
                         m_writer.WriteLine("");     // Empty line
 
-                        if (group.LogEnd.Id != group.LogStart.Id)
+                        if (group.LogEnd != null && group.LogEnd.Id != group.LogStart.Id)
                         {
                             m_writer.WriteLine("##[group] " + group.Name + " - execution log");
                             indent.Push(indent.Peek() + "    ");
@@ -179,6 +179,16 @@ namespace StepBro.Core.Addons
                             indent.Pop();
                             m_writer.WriteLine("##[endgroup]");
                             m_writer.WriteLine("");     // Empty line
+                        }
+                        else if (group.LogEnd == null)
+                        {
+                            m_writer.WriteLine("##[error] An error has occurred. Dumping log.");
+                            var entry = group.LogStart;
+                            while (entry != null)
+                            {
+                                WriteLogEntry(entry, entry.Timestamp);
+                                entry = entry.Next;
+                            }
                         }
                     }
                 }

--- a/source/StepBro.Core/Addons/OutputConsoleWithColorsAddon.cs
+++ b/source/StepBro.Core/Addons/OutputConsoleWithColorsAddon.cs
@@ -83,7 +83,7 @@ namespace StepBro.Core.Addons
 
             public void WriteReport(DataReport report)
             {
-                throw new NotImplementedException();
+                throw new NotImplementedException("Test reports are not yet supported for console format.");
             }
 
             void ITextWriter.Write(string text)


### PR DESCRIPTION
--print_report now dumps the log if an error occurs that has made it unable to get an end to a log-group.

Fixes #110 