### PR TITLE
Fix re-parsing of files using 'typedef's.

### DIFF
--- a/source/StepBro.Core/Interface/Main.cs
+++ b/source/StepBro.Core/Interface/Main.cs
@@ -279,12 +279,6 @@ namespace StepBro.Core
                     {
                         try
                         {
-                            context.UpdateStatus($"Resetting files ({(force ? "forced" : "not forced")})");
-                            foreach (var f in m_loadedFilesManager.ListFiles<ScriptFile>())
-                            {
-                                f.ResetBeforeParsing(preserveUpdateableElements: force == false);
-                            }
-
                             context.UpdateStatus("Parsing files");
                             m_lastParsingErrorCount = FileBuilder.ParseFiles(m_serviceManagerAdmin.Manager, context.Logger, (IScriptFile)null);
                         }
@@ -328,12 +322,6 @@ namespace StepBro.Core
                 try
                 {
                     logger = m_logRootScope.LogEntering(true, "StepBro.Main.FileParsing", "Starting file parsing", null);
-                    foreach (var f in m_loadedFilesManager.ListFiles<ScriptFile>())
-                    {
-                        f.ResetBeforeParsing(preserveUpdateableElements: true);
-                        //f.ResetBeforeParsing(preserveUpdateableElements: force == false);
-                    }
-
                     m_lastParsingErrorCount = FileBuilder.ParseFiles(m_serviceManagerAdmin.Manager, logger, (IScriptFile)null);
                 }
                 finally

--- a/source/StepBro.Core/Parser/StepBroListener.ExpressionMethodCall.cs
+++ b/source/StepBro.Core/Parser/StepBroListener.ExpressionMethodCall.cs
@@ -160,7 +160,7 @@ namespace StepBro.Core.Parser
                         return;
 
                     case SBExpressionType.Identifier:
-                        m_errors.SymanticError(left.Token.Line, left.Token.Column, false, $"\"{left.ToString()}\" is unresolved.");
+                        m_errors.SymanticError(left.Token.Line, left.Token.Column, false, $"\"{(string)(left.Value)}\" is unresolved.");
                         return;
 
                     case SBExpressionType.Expression:

--- a/source/StepBro.Core/Parser/StepBroListener.cs
+++ b/source/StepBro.Core/Parser/StepBroListener.cs
@@ -713,7 +713,7 @@ namespace StepBro.Core.Parser
 
         public override void EnterFileElementOverride([NotNull] SBP.FileElementOverrideContext context)
         {
-            m_currentFileElement = new FileElementOverride(m_file, context.Start.Line, null, m_currentNamespace, "");
+            m_currentFileElement = new FileElementOverride(m_file, context.Start.Line, null, "");
         }
 
         public override void ExitFileElementOverride([NotNull] SBP.FileElementOverrideContext context)

--- a/source/StepBro.Core/ScriptData/FileElement.cs
+++ b/source/StepBro.Core/ScriptData/FileElement.cs
@@ -20,12 +20,20 @@ namespace StepBro.Core.ScriptData
         private string m_summary;
         private string m_docReference;
         private static int g_nextID = 1000;
-        private readonly int m_uid = g_nextID++;
+        protected readonly int m_uid = g_nextID++;
         protected PropertyBlock m_propertyBlock = null;
         private readonly List<IPartner> m_partners = new List<IPartner>();
 
         public FileElement(IScriptFile file, int line, IFileElement parentElement, string @namespace, string name, AccessModifier access, FileElementType type)
         {
+            System.Diagnostics.Debug.WriteLine(
+                "~~~~~~~~ FILE ELEMENT " +
+                type.ToString().ToUpper() + ": " +
+                m_uid.ToString() + " " +
+                ((file != null) ? file.FileName : "<no file>") + " - " +
+                (String.IsNullOrEmpty(@namespace) ? "" : @namespace) + " " +
+                name);
+
             m_parentFile = file;
             m_line = line;
             m_baseElement = null;

--- a/source/StepBro.Core/ScriptData/FileElementOverride.cs
+++ b/source/StepBro.Core/ScriptData/FileElementOverride.cs
@@ -15,8 +15,8 @@ namespace StepBro.Core.ScriptData
         private Tuple<string, IToken> m_asTypeData = null;
         private TypeReference m_asType = null;
 
-        public FileElementOverride(IScriptFile file, int line, IFileElement parentElement, string @namespace, string name) 
-            : base(file, line, parentElement, @namespace, name, AccessModifier.None, FileElementType.Override)
+        public FileElementOverride(IScriptFile file, int line, IFileElement parentElement, string name) 
+            : base(file, line, parentElement, file.Namespace, name, AccessModifier.None, FileElementType.Override)
         {
             this.BaseElementName = name;
         }

--- a/source/StepBro.Core/ScriptData/FileElementTypeDef.cs
+++ b/source/StepBro.Core/ScriptData/FileElementTypeDef.cs
@@ -31,7 +31,19 @@ namespace StepBro.Core.ScriptData
                 var numUnresolved = listener.ParseTypedef(m_declaration, reportErrors: reportErrors, token: m_declaration.Token);
                 if (numUnresolved == 0 && m_declaration.ResolvedType != null)
                 {
-                    m_typeReference = new TypeReference(new TypeDef(this.Name, m_declaration.ResolvedType));
+                    var type = new TypeReference(new TypeDef(this.Name, m_declaration.ResolvedType));
+                    if (m_typeReference == null || 
+                        !Object.ReferenceEquals(type.Type, m_typeReference.Type) ||
+                        !String.Equals((type.DynamicType as TypeDef).Name, (m_typeReference.DynamicType as TypeDef).Name) ||
+                        !Object.ReferenceEquals((type.DynamicType as TypeDef).Type.Type, (m_typeReference.DynamicType as TypeDef).Type.Type) ||
+                        !Object.ReferenceEquals((type.DynamicType as TypeDef).Type.DynamicType, (m_typeReference.DynamicType as TypeDef).Type.DynamicType))
+                    {
+                        m_typeReference = type;
+                    }
+                }
+                else
+                {
+                    m_typeReference = null;
                 }
                 return numUnresolved;
             }


### PR DESCRIPTION
Re-use 'typedef's and 'override's file elements between parsings. 
Keep/re-use typedef definition objects between parsings,, because there are references to them in different parts of the system. 
Throw away saved root identifiers before each parsing.