### PR TITLE
Improve stepbro syntax highlighting

### DIFF
--- a/additional/stepbro-syntax-highlighting/syntaxes/stepbro.tmLanguage.json
+++ b/additional/stepbro-syntax-highlighting/syntaxes/stepbro.tmLanguage.json
@@ -52,7 +52,7 @@
                 },
                 {
                     "name": "keyword.other.using.stepbro",
-                    "match": "\\b(using)\\b"
+                    "match": "\\b([public ]*using)\\b"
                 },
                 {
                     "name": "keyword.other.stepbro",
@@ -92,7 +92,7 @@
             [
                 {
                     "name": "entity.name.function.stepbro",
-                    "match": "procedure"
+                    "match": "\\bprocedure\\b"
                 },
                 {
                     "name": "keyword.other.protection.stepbro",

--- a/additional/stepbro-syntax-highlighting/syntaxes/stepbro.tmLanguage.json
+++ b/additional/stepbro-syntax-highlighting/syntaxes/stepbro.tmLanguage.json
@@ -92,7 +92,7 @@
             [
                 {
                     "name": "entity.name.function.stepbro",
-                    "match": "\\bprocedure\\b"
+                    "match": "\\b(procedure|function)\\b"
                 },
                 {
                     "name": "keyword.other.protection.stepbro",
@@ -104,7 +104,7 @@
                 },
                 {
                     "name": "entity.name.function.inherited.stepbro",
-                    "match": "(?<=procedure .*:[ ]*)[a-zA-Z][a-zA-Z0-9]*"
+                    "match": "(?<=(procedure|function) .*:[ ]*)[a-zA-Z][a-zA-Z0-9]*"
                 },
                 {
                     "name": "entity.name.function.override.stepbro",
@@ -157,7 +157,7 @@
             [
                 {
                     "name": "support.type.built-in.object-name.stepbro",
-                    "match": "(?<=(public|private)) (?!procedure)[a-zA-Z][a-zA-Z0-9]*"
+                    "match": "(?<=(public|private)) (?!(procedure|function))[a-zA-Z][a-zA-Z0-9]*"
                 },
                 {
                     "name": "support.type.argument.stepbro",

--- a/additional/stepbro-syntax-highlighting/syntaxes/stepbro.tmLanguage.json
+++ b/additional/stepbro-syntax-highlighting/syntaxes/stepbro.tmLanguage.json
@@ -44,7 +44,7 @@
                 },
                 {
                     "name": "keyword.other.types.stepbro",
-                    "match": "\\b(bool|void|testlist|int|string|type|namespace)\\b"
+                    "match": "\\b(bool|void|testlist|int|integer|decimal|verdict|datetime|timespan|string|type|namespace|var|double|object)\\b"
                 },
                 {
                     "name": "keyword.other.step.stepbro",
@@ -173,7 +173,7 @@
                 },
                 {
                     "name": "support.type.built-in.property-name.stepbro",
-                    "match": "(?<![a-zA-Z][a-zA-Z0-9]*[ ]+)\\b[a-zA-Z][a-zA-Z0-9]*\\b(?=[ ]*\\=)"
+                    "match": "(?<![a-zA-Z][a-zA-Z0-9]*[ ]+)\\b[a-zA-Z][a-zA-Z0-9]*\\b(?=[ ]*\\=?![ ]*\\=)"
                 }
             ]
         },

--- a/additional/stepbro-syntax-highlighting/syntaxes/stepbro.tmLanguage.json
+++ b/additional/stepbro-syntax-highlighting/syntaxes/stepbro.tmLanguage.json
@@ -40,7 +40,7 @@
             [
                 {
                     "name": "keyword.control.stepbro",
-                    "match": "\\b(if|while|for|return)\\b"
+                    "match": "\\b(if|while|for|return|else)\\b"
                 },
                 {
                     "name": "keyword.other.types.stepbro",
@@ -48,19 +48,27 @@
                 },
                 {
                     "name": "keyword.other.step.stepbro",
-                    "match": "step"
+                    "match": "\\b(step)\\b"
                 },
                 {
                     "name": "keyword.other.using.stepbro",
-                    "match": "using"
+                    "match": "\\b(using)\\b"
                 },
                 {
                     "name": "keyword.other.stepbro",
                     "match": "\\b(true|false|override|this)\\b"
                 },
                 {
-                    "name": "keyword.control.partner.stepbro",
-                    "match": "partner"
+                    "name": "keyword.other.partner.stepbro",
+                    "match": "\\b(partner)\\b"
+                },
+                {
+                    "name": "keyword.other.await.stepbro",
+                    "match": "\\b(await)\\b"
+                },
+                {
+                    "name": "keyword.other.as.stepbro",
+                    "match": "\\b(as)\\b"
                 }
             ]
         },
@@ -158,6 +166,14 @@
                 {
                     "name": "support.type.argument.stepbro",
                     "match": "(?<=(\\(.*,[ ]*(this)*[ ]*))[a-zA-Z][a-zA-Z0-9]*[ ]+(?![^a-zA-Z])"
+                },
+                {
+                    "name": "support.type.definition.stepbro",
+                    "match": "([a-zA-Z][a-zA-Z0-9]*)[ ]+(?=[a-zA-Z][a-zA-Z0-9]*[ ]*\\=)"
+                },
+                {
+                    "name": "support.type.built-in.property-name.stepbro",
+                    "match": "(?<![a-zA-Z][a-zA-Z0-9]*[ ]+)\\b[a-zA-Z][a-zA-Z0-9]*\\b(?=[ ]*\\=)"
                 }
             ]
         },
@@ -191,11 +207,15 @@
             [
                 {
                     "name": "support.type.built-in.object-name.stepbro",
-                    "match": "(?<=(type)) [a-zA-Z][a-zA-Z0-9]*"
+                    "match": "(?<=(type))[ ]+[a-zA-Z][a-zA-Z0-9]*"
                 },
                 {
                     "name": "support.type.built-in.object-name.stepbro",
                     "match": "(?<=(type [a-zA-Z][a-zA-Z0-9]*[ ]*:))[ ]*[a-zA-Z][a-zA-Z0-9]*"
+                },
+                {
+                    "name": "support.type.override.built-in.object-name.stepbro",
+                    "match": "(?<=(override [a-zA-Z][a-zA-Z0-9]*[ ]+as))[ ]+[a-zA-Z][a-zA-Z0-9]*"
                 }
             ]
         },

--- a/additional/stepbro-syntax-highlighting/syntaxes/stepbro.tmLanguage.json
+++ b/additional/stepbro-syntax-highlighting/syntaxes/stepbro.tmLanguage.json
@@ -63,7 +63,7 @@
                     "match": "\\b(partner)\\b"
                 },
                 {
-                    "name": "keyword.other.await.stepbro",
+                    "name": "entity.other.attribute-name.await.stepbro",
                     "match": "\\b(await)\\b"
                 },
                 {


### PR DESCRIPTION
Fix a couple issues where syntax highlighting could show up in the middle of a word
Change color of "await"
Add syntax highlighting to all primitive types
Add syntax highlighting to types
Add syntax highlighting to (some?) properties