### PR TITLE
Add arguments to ProcedureActivationButton

### DIFF
--- a/source/StepBro.ConsoleSidekick.WinForms/MainForm.Designer.cs
+++ b/source/StepBro.ConsoleSidekick.WinForms/MainForm.Designer.cs
@@ -86,7 +86,7 @@
             // toolStripMenuItemClearDisplay
             // 
             toolStripMenuItemClearDisplay.Name = "toolStripMenuItemClearDisplay";
-            toolStripMenuItemClearDisplay.Size = new Size(142, 22);
+            toolStripMenuItemClearDisplay.Size = new Size(180, 22);
             toolStripMenuItemClearDisplay.Text = "Clear Display";
             toolStripMenuItemClearDisplay.Click += toolStripMenuItemClearDisplay_Click;
             // 
@@ -94,7 +94,7 @@
             // 
             toolStripMenuItemShortcuts.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemDeleteShortcut, toolStripMenuItemDeleteAllShortcuts });
             toolStripMenuItemShortcuts.Name = "toolStripMenuItemShortcuts";
-            toolStripMenuItemShortcuts.Size = new Size(142, 22);
+            toolStripMenuItemShortcuts.Size = new Size(180, 22);
             toolStripMenuItemShortcuts.Text = "Shortcuts";
             // 
             // toolStripMenuItemDeleteShortcut
@@ -116,7 +116,7 @@
             // 
             toolStripMenuItemView.DropDownItems.AddRange(new ToolStripItem[] { toolStripMenuItemExeNoteInput });
             toolStripMenuItemView.Name = "toolStripMenuItemView";
-            toolStripMenuItemView.Size = new Size(142, 22);
+            toolStripMenuItemView.Size = new Size(180, 22);
             toolStripMenuItemView.Text = "View";
             // 
             // toolStripMenuItemExeNoteInput
@@ -130,12 +130,12 @@
             // toolStripSeparator1
             // 
             toolStripSeparator1.Name = "toolStripSeparator1";
-            toolStripSeparator1.Size = new Size(139, 6);
+            toolStripSeparator1.Size = new Size(177, 6);
             // 
             // toolStripMenuItemExit
             // 
             toolStripMenuItemExit.Name = "toolStripMenuItemExit";
-            toolStripMenuItemExit.Size = new Size(142, 22);
+            toolStripMenuItemExit.Size = new Size(180, 22);
             toolStripMenuItemExit.Text = "Exit";
             toolStripMenuItemExit.Click += toolStripMenuItemExit_Click;
             // 

--- a/source/StepBro.ConsoleSidekick.WinForms/MainForm.cs
+++ b/source/StepBro.ConsoleSidekick.WinForms/MainForm.cs
@@ -1101,7 +1101,12 @@ namespace StepBro.ConsoleSidekick.WinForms
         {
             var execution = new ExecutionAccess(this, m_pipe);
             m_activeExecutions.Add(new WeakReference<ExecutionAccess>(execution));
-            var request = new RunScriptRequest(execution.ID, false, element, model, objectVariable);
+            List<Argument> arguments = null;
+            if (args != null)
+            {
+                arguments = args.Select(a => new Argument(a)).ToList();
+            }
+            var request = new RunScriptRequest(execution.ID, false, element, model, objectVariable, arguments);
             if (toolStripTextBoxExeNote.Visible)
             {
                 request.ExecutionNote = toolStripTextBoxExeNote.Text;

--- a/source/StepBro.ConsoleSidekick.WinForms/MainForm.resx
+++ b/source/StepBro.ConsoleSidekick.WinForms/MainForm.resx
@@ -18,7 +18,7 @@
     <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
     <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
     <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
-    <data name="Color1" type="System.Drawing.Color, System.Drawing"">Blue</data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
     <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
         <value>[base64 mime encoded serialized .NET Framework object]</value>
     </data>

--- a/source/StepBro.Core/Host/ToolBarCreator/ToolBar.cs
+++ b/source/StepBro.Core/Host/ToolBarCreator/ToolBar.cs
@@ -50,11 +50,14 @@ namespace StepBro.ToolBarCreator
             var color = new PropertyBlockDecoder.ValueString<object>("Color");
             var text = new PropertyBlockDecoder.ValueString<object>("Text");
             var instance = new PropertyBlockDecoder.ValueString<object>("Instance");
+            var procedure = new PropertyBlockDecoder.ValueString<object>("Procedure", "Element");
 
             var procButton = new PropertyBlockDecoder.Block<object, object>("ProcedureActivationButton",
                 color, text, instance,
-                new PropertyBlockDecoder.ValueString<object>("Procedure"),
+                new PropertyBlockDecoder.ValueString<object>("Procedure", "Element"),
                 new PropertyBlockDecoder.ValueString<object>("Partner"),
+                new PropertyBlockDecoder.Value<object>("Arg", "Argument"),
+                new PropertyBlockDecoder.Array<object>("Args", "Arguments"),
                 new PropertyBlockDecoder.Flag<object>("Stoppable"),
                 new PropertyBlockDecoder.Flag<object>("StopOnButtonRelease")
                 );
@@ -64,7 +67,7 @@ namespace StepBro.ToolBarCreator
                 );
 
             var menu = new PropertyBlockDecoder.Block<object, object>("Menu");
-            menu.SetChilds(menu, procButton, objCmdButton);
+            menu.SetChilds(menu, procButton, objCmdButton, instance);
 
             var root = new PropertyBlockDecoder.Block<object, object>
                 (
@@ -73,7 +76,7 @@ namespace StepBro.ToolBarCreator
                     new PropertyBlockDecoder.ValueInt<object>("Priority"),
                     new PropertyBlockDecoder.Flag<object>("Separator"),
                     new PropertyBlockDecoder.Flag<object>("ColumnSeparator"),
-                    menu, procButton, objCmdButton
+                    menu, procButton, objCmdButton, instance
                 );
             root.DecodeData(data, null, errors);
         }

--- a/source/StepBro.Core/Host/ToolBarCreator/ToolBarElement.cs
+++ b/source/StepBro.Core/Host/ToolBarCreator/ToolBarElement.cs
@@ -38,6 +38,16 @@ namespace StepBro.ToolBarCreator
         object GetProperty([Implicit] ICallContext context, string property);
         IToolBarElement TryFindChildElement([Implicit] ICallContext context, string name);
         IEnumerable<IToolBarElement> GetChilds();
+        object TryGetChildProperty(string name);
+    }
+
+    public static class ToolBarSupport
+    {
+        public static string GetQualifiedName(this IToolBarElement element)
+        {
+            if (element.ParentElement == null) { return element.ElementName; }
+            else return GetQualifiedName(element.ParentElement) + "." + element.ElementName;
+        }
     }
 
     //[Public]

--- a/source/StepBro.UI.WinForms/CustomToolBar/ObjectCommandButton.cs
+++ b/source/StepBro.UI.WinForms/CustomToolBar/ObjectCommandButton.cs
@@ -6,6 +6,7 @@ using StepBro.ToolBarCreator;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -15,12 +16,15 @@ namespace StepBro.UI.WinForms.CustomToolBar
 {
     public class ObjectCommandButton : ToolStripMenuItem, IToolBarElement
     {
+        private IToolBarElement m_parent;
         private ICoreAccess m_coreAccess = null;
         private string m_object = null;
         private string m_command = null;
 
-        public ObjectCommandButton(ICoreAccess coreAccess, string name) : base()
+        public ObjectCommandButton(IToolBarElement parent, ICoreAccess coreAccess, string name) : base()
         {
+            Debug.Assert(parent != null);
+            m_parent = parent;
             m_coreAccess = coreAccess;
             this.Margin = new Padding(1, Margin.Top, 1, Margin.Bottom);
             this.Name = name;
@@ -29,7 +33,7 @@ namespace StepBro.UI.WinForms.CustomToolBar
 
         public string ObjectInstance
         {
-            get { return m_object; }
+            get { return (m_object != null) ? m_object : (string)m_parent.TryGetChildProperty("Instance"); }
             set { m_object = value; }
         }
         public string ObjectCommand
@@ -40,14 +44,14 @@ namespace StepBro.UI.WinForms.CustomToolBar
 
         protected override void OnClick(EventArgs e)
         {
-            m_coreAccess.ExecuteObjectCommand(m_object, m_command);
+            m_coreAccess.ExecuteObjectCommand(this.ObjectInstance, m_command);
         }
 
         #region IToolBarElement
 
         public uint Id => throw new NotImplementedException();
 
-        public IToolBarElement ParentElement => throw new NotImplementedException();
+        public IToolBarElement ParentElement { get { return m_parent; } }
 
         public string PropertyName => throw new NotImplementedException();
 
@@ -87,7 +91,11 @@ namespace StepBro.UI.WinForms.CustomToolBar
             throw new NotImplementedException();
         }
 
-        #endregion
+        public object TryGetChildProperty(string name)
+        {
+            return null;
+        }
 
+        #endregion
     }
 }

--- a/source/StepBro.UI.WinForms/CustomToolBar/ToolStripDropDownMenu.cs
+++ b/source/StepBro.UI.WinForms/CustomToolBar/ToolStripDropDownMenu.cs
@@ -7,14 +7,26 @@ namespace StepBro.UI.WinForms.CustomToolBar
 {
     internal class ToolStripDropDownMenu : ToolStripDropDownButton, IToolBarElement, IMenu, IMenuItemHost
     {
+        private IToolBarElement m_parent;
         private ICoreAccess m_coreAccess = null;
+        private Dictionary<string, object> m_commonChildFields = null;
 
-        public ToolStripDropDownMenu(ICoreAccess coreAccess, string name) : base()
+        public ToolStripDropDownMenu(IToolBarElement parent, ICoreAccess coreAccess, string name) : base()
         {
+            m_parent = parent;
             m_coreAccess = coreAccess;
             this.Margin = new Padding(1, Margin.Top, 1, Margin.Bottom);
             this.Name = name;
             this.Text = name;
+        }
+
+        internal void SetChildProperty(string name, object value)
+        {
+            if (m_commonChildFields == null)
+            {
+                m_commonChildFields = new Dictionary<string, object>();
+            }
+            m_commonChildFields[name] = value;
         }
 
         public void SetTitle(string title)
@@ -31,7 +43,7 @@ namespace StepBro.UI.WinForms.CustomToolBar
 
         public uint Id => throw new NotImplementedException();
 
-        public IToolBarElement ParentElement => throw new NotImplementedException();
+        public IToolBarElement ParentElement { get { return m_parent; } }
 
         public string PropertyName => throw new NotImplementedException();
 
@@ -69,6 +81,15 @@ namespace StepBro.UI.WinForms.CustomToolBar
         public IToolBarElement TryFindChildElement([Implicit] ICallContext context, string name)
         {
             throw new NotImplementedException();
+        }
+
+        public object TryGetChildProperty(string name)
+        {
+            if (m_commonChildFields != null && m_commonChildFields.ContainsKey(name))
+            {
+                return m_commonChildFields[name];
+            }
+            return m_parent.TryGetChildProperty(name);
         }
 
         #endregion

--- a/source/StepBro.UI.WinForms/CustomToolBar/ToolStripMenuSubMenu.cs
+++ b/source/StepBro.UI.WinForms/CustomToolBar/ToolStripMenuSubMenu.cs
@@ -14,13 +14,25 @@ namespace StepBro.UI.WinForms.CustomToolBar
 {
     internal class ToolStripMenuSubMenu : ToolStripMenuItem, IMenu, IToolBarElement
     {
+        private IToolBarElement m_parent;
         private ICoreAccess m_coreAccess = null;
+        private Dictionary<string, object> m_commonChildFields = null;
 
-        public ToolStripMenuSubMenu(ICoreAccess coreAccess, string name) : base()
+        public ToolStripMenuSubMenu(IToolBarElement parent, ICoreAccess coreAccess, string name) : base()
         {
+            m_parent = parent;
             m_coreAccess = coreAccess;
             this.Name = name;
             this.Text = name;
+        }
+
+        internal void SetChildProperty(string name, object value)
+        {
+            if (m_commonChildFields == null)
+            {
+                m_commonChildFields = new Dictionary<string, object>();
+            }
+            m_commonChildFields[name] = value;
         }
 
         public void SetTitle(string title)
@@ -33,7 +45,7 @@ namespace StepBro.UI.WinForms.CustomToolBar
 
         public uint Id => throw new NotImplementedException();
 
-        public IToolBarElement ParentElement => throw new NotImplementedException();
+        public IToolBarElement ParentElement { get { return m_parent; } }
 
         public string PropertyName => throw new NotImplementedException();
 
@@ -71,6 +83,15 @@ namespace StepBro.UI.WinForms.CustomToolBar
         public IToolBarElement TryFindChildElement([Implicit] ICallContext context, string name)
         {
             throw new NotImplementedException();
+        }
+
+        public object TryGetChildProperty(string name)
+        {
+            if (m_commonChildFields != null && m_commonChildFields.ContainsKey(name))
+            {
+                return m_commonChildFields[name];
+            }
+            return m_parent.TryGetChildProperty(name);
         }
 
         #endregion

--- a/source/StepBro.UI.WinForms/ProcedureActivationButtonLogic.cs
+++ b/source/StepBro.UI.WinForms/ProcedureActivationButtonLogic.cs
@@ -1,6 +1,7 @@
 ﻿using StepBro.Core.Api;
 using StepBro.Core.Data;
 using StepBro.Core.Tasks;
+using StepBro.ToolBarCreator;
 
 namespace StepBro.UI.WinForms
 {
@@ -30,7 +31,7 @@ namespace StepBro.UI.WinForms
             ShowWaitSymbol
         }
 
-        public interface IProcedureActivationButton
+        public interface IProcedureActivationButton : IToolBarElement
         {
             void CommandHandler(ButtonCommand command);
             void BeginInvoke(Action action);
@@ -132,7 +133,17 @@ namespace StepBro.UI.WinForms
                     this.SendCommand(ButtonCommand.ShowActive);
                     this.SendCommand(ButtonCommand.ShowStopSymbol);
                 }
-                m_execution = m_coreAccess.StartExecution(m_startProcedure.Name, m_startProcedure.Partner, m_startProcedure.TargetObject, null);
+
+                string element = m_startProcedure.Name;
+                if (element == null) { element = m_parentControl.ParentElement.TryGetChildProperty("Element") as string; }
+                string partner = m_startProcedure.Partner;
+                if (partner == null) { partner = m_parentControl.ParentElement.TryGetChildProperty("Partner") as string; }
+                string instance = m_startProcedure.TargetObject;
+                if (instance == null) { instance = m_parentControl.ParentElement.TryGetChildProperty("Instance") as string; }
+
+                List<object> arguments = m_startProcedure.Arguments;
+
+                m_execution = m_coreAccess.StartExecution(element, partner, instance, (arguments != null) ? arguments.ToArray() : null);
                 m_execution.CurrentStateChanged += Execution_CurrentStateChanged;
                 System.Diagnostics.Debug.WriteLine("StartProcedure End");
             }

--- a/source/StepBro.UI.WinForms/ProcedureActivationInfo.cs
+++ b/source/StepBro.UI.WinForms/ProcedureActivationInfo.cs
@@ -11,7 +11,7 @@ namespace StepBro.UI.WinForms
         public string Name { get; set; } = null;
         public string Partner { get; set; } = null;
         public string TargetObject { get; set; } = null;
-        //public bool FirstParameterIsSelf { get; set; } = false;
+        public List<object> Arguments { get; set; } = null;
         public bool IsUsed { get { return !string.IsNullOrEmpty(Name); } }
     }
 }

--- a/source/StepBro.UI.WinForms/WinFormsPropertyBlockDecoder.cs
+++ b/source/StepBro.UI.WinForms/WinFormsPropertyBlockDecoder.cs
@@ -6,7 +6,7 @@ namespace StepBro.UI.WinForms
 {
     internal static class WinFormsPropertyBlockDecoder
     {
-        public class ValueColor<TParent> : Value<TParent> where TParent : class
+        public class ValueColor<TParent> : ValueBase<TParent> where TParent : class
         {
             private Func<TParent, Color, string> m_setter;
 

--- a/source/stepbro/ConsoleSidekickMessages.cs
+++ b/source/stepbro/ConsoleSidekickMessages.cs
@@ -14,14 +14,19 @@ namespace StepBro.Sidekick.Messages
 
     public class Argument
     {
+        public Argument() { }
+
         public Argument(object value)
         {
             if (value == null) throw new ArgumentNullException("value");
-            if (value is string) { this.Type = "string"; this.Value = value as string; }
-            if (value is long) { this.Type = "int"; this.Value = value.ToString(); }
-            if (value is bool) { this.Type = "bool"; this.Value = value.ToString(); }
-            if (value is Identifier) { this.Type = "identifier"; this.Value = ((Identifier)value).Name; }
-            throw new ArgumentException("value");
+            else if (value is string) { this.Type = "string"; this.Value = value as string; }
+            else if (value is long || value is int) { this.Type = "int"; this.Value = value.ToString(); }
+            else if (value is bool) { this.Type = "bool"; this.Value = value.ToString(); }
+            else if (value is Identifier) { this.Type = "identifier"; this.Value = ((Identifier)value).Name; }
+            else 
+            {
+                throw new ArgumentException("value");
+            }
         }
         public string Type { get; set; } = null;
         public string Value { get; set; } = null;
@@ -195,19 +200,19 @@ namespace StepBro.Sidekick.Messages
 
     public class RunScriptRequest : RequestOrResponse
     {
-        public RunScriptRequest(ulong requestID, bool silent, string element, string partner, string objectReference, Argument[] arguments = null) : base(requestID)
+        public RunScriptRequest(ulong requestID, bool silent, string element, string partner, string objectReference, List<Argument> arguments = null) : base(requestID)
         {
             this.Silent = silent;
             this.Element = element;
             this.Partner = partner;
             this.ObjectReference = objectReference;
-            this.Arguments = arguments;
+            this.Arguments = (arguments != null) ? arguments.ToList() : null;
         }
         public bool Silent { get; set; }
         public string Element { get; set; }
         public string Partner { get; set; }
         public string ObjectReference { get; set; }
-        public Argument[] Arguments { get; set; }
+        public List<Argument> Arguments { get; set; } = null;
     }
 
     public class StopExecutionRequest : RequestOrResponse

--- a/source/stepbro/Program.cs
+++ b/source/stepbro/Program.cs
@@ -1,4 +1,4 @@
-﻿//#define STOP_BEFORE_PARSING
+﻿#define STOP_BEFORE_PARSING
 using StepBro.Core;
 using StepBro.Core.Addons;
 using StepBro.Core.Api;
@@ -20,6 +20,7 @@ using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Xml.Linq;
 using StepBroMain = StepBro.Core.Main;
 
 namespace StepBro.Cmd
@@ -82,6 +83,8 @@ namespace StepBro.Cmd
             string targetElement = null;
             string targetPartner = null;
             string targetObject = null;
+            List<object> targetArguments = null;
+
             ulong targetExecutionStartRequestID = 0UL;
 
             try
@@ -187,6 +190,8 @@ namespace StepBro.Cmd
                 targetElement = m_commandLineOptions.TargetElement;
                 targetObject = m_commandLineOptions.TargetInstance;
                 targetPartner = m_commandLineOptions.TargetModel;
+                targetArguments = m_commandLineOptions?.Arguments.Select((a) => StepBroMain.ParseExpression(element?.ParentFile, a)).ToList();
+
 
                 if (!String.IsNullOrEmpty(targetFile))
                 {
@@ -365,7 +370,11 @@ namespace StepBro.Cmd
                                     {
                                         var objectCommand = JsonSerializer.Deserialize<StepBro.Sidekick.Messages.ObjectCommand>(input.Item2);
 
-                                        if (commandObjectDictionary.ContainsKey(objectCommand.Object) && !String.IsNullOrEmpty(objectCommand.Command))
+                                        if (String.IsNullOrEmpty(objectCommand.Object))
+                                        {
+                                            StepBroMain.Logger.RootLogger.LogError("Missing object reference in object command.");
+                                        }
+                                        else if (commandObjectDictionary.ContainsKey(objectCommand.Object) && !String.IsNullOrEmpty(objectCommand.Command))
                                         {
                                             string name = objectCommand.Object.Split('.').Last();
                                             StepBroMain.Logger.RootLogger.LogUserAction($"Request run '{name}' command \"{objectCommand.Command}\"");
@@ -390,6 +399,11 @@ namespace StepBro.Cmd
                                         targetElement = request.Element;
                                         targetPartner = request.Partner;
                                         targetObject = request.ObjectReference;
+                                        targetArguments = null;
+                                        if (request.Arguments != null)
+                                        {
+                                            targetArguments = request.Arguments.Select((a) => a.GetValue()).ToList();
+                                        }
 
                                         string objectInstanceText = String.IsNullOrEmpty(request.ObjectReference) ? "" : (request.ObjectReference.Split('.').Last() + ".");
                                         string partnertext = String.IsNullOrEmpty(targetPartner) ? "" : (" @ " + targetPartner);
@@ -669,9 +683,6 @@ namespace StepBro.Cmd
                                     partner = null;
                                     if (element != null)
                                     {
-                                        List<object> arguments = m_commandLineOptions?.Arguments.Select(
-                                            (a) => StepBroMain.ParseExpression(element?.ParentFile, a)).ToList();
-
                                         if (!String.IsNullOrEmpty(targetPartner))
                                         {
                                             partner = element.ListPartners().First(p => String.Equals(targetPartner, p.Name, StringComparison.InvariantCultureIgnoreCase));
@@ -683,21 +694,31 @@ namespace StepBro.Cmd
                                         }
                                         else
                                         {
-                                            if (!String.IsNullOrEmpty(targetObject))
+                                            if (element is IFileProcedure)
                                             {
-                                                var theObject = objectManager.GetObjectCollection().FirstOrDefault(v => string.Equals(v.FullName, targetObject, StringComparison.InvariantCulture));
-                                                if (theObject != null)
+                                                var procedure = (IFileProcedure)element;
+
+                                                // NOTE: targetObject might be set, even if it should not be used.
+
+                                                if (!String.IsNullOrEmpty(targetObject) && procedure.IsFirstParameterThisReference)
                                                 {
-                                                    arguments.Insert(0, theObject.Object);
-                                                }
-                                                else
-                                                {
-                                                    ConsoleWriteErrorLine($"Error: Target object '{targetObject}' was not found in the list of global variables.");
-                                                    error = true;
+                                                    var theObject = objectManager.GetObjectCollection().FirstOrDefault(v => string.Equals(v.FullName, targetObject, StringComparison.InvariantCulture));
+                                                    if (theObject != null)
+                                                    {
+                                                        if (targetArguments == null)
+                                                        {
+                                                            targetArguments = new List<object>();
+                                                        }
+                                                        targetArguments.Insert(0, theObject.Object);
+                                                    }
+                                                    else
+                                                    {
+                                                        ConsoleWriteErrorLine($"Error: Target object '{targetObject}' was not found in the list of global variables.");
+                                                        error = true;
+                                                    }
                                                 }
                                             }
-
-                                            if (!(element is IFileProcedure))
+                                            else
                                             {
                                                 ConsoleWriteErrorLine($"Error: Target element (type {element.ElementType}) is not a supported type for execution.");
                                                 error = true;
@@ -716,7 +737,7 @@ namespace StepBro.Cmd
                                                 }
                                                 if (sidekickStarted)
                                                 {
-                                                    execution = StepBroMain.StartProcedureExecution(element, partner, arguments.ToArray());
+                                                    execution = StepBroMain.StartProcedureExecution(element, partner, targetArguments.ToArray());
                                                     if (targetExecutionStartRequestID != 0UL)
                                                     {
                                                         m_requestObjectDictionary.Add(new Tuple<ulong, object>(targetExecutionStartRequestID, execution));
@@ -726,7 +747,7 @@ namespace StepBro.Cmd
                                                 }
                                                 else
                                                 {
-                                                    execution = StepBroMain.ExecuteProcedure(element, partner, arguments.ToArray());
+                                                    execution = StepBroMain.ExecuteProcedure(element, partner, targetArguments.ToArray());
                                                 }
 
                                                 executionStarted = true;

--- a/source/stepbro/Program.cs
+++ b/source/stepbro/Program.cs
@@ -1,4 +1,4 @@
-﻿#define STOP_BEFORE_PARSING
+﻿//#define STOP_BEFORE_PARSING
 using StepBro.Core;
 using StepBro.Core.Addons;
 using StepBro.Core.Api;


### PR DESCRIPTION
Add 'Arg', 'Argument', 'Args', and 'Arguments' to the toolbar definition of the button. Add arguments to the sidekick communication execution command. Support common fields 'Procedure', 'Element', and 'Instance'.