### PR TITLE
172

### DIFF
--- a/source/StepBro.Core/ScriptData/FileElement.cs
+++ b/source/StepBro.Core/ScriptData/FileElement.cs
@@ -108,11 +108,19 @@ namespace StepBro.Core.ScriptData
             }
             internal set
             {
-                // Assume not the same element.
-                System.Diagnostics.Debug.Assert(value != null && !object.ReferenceEquals(value, this));
-                // Assume not both override elements or elements are from different files.
-                System.Diagnostics.Debug.Assert(this.ElementType != FileElementType.Override || value.ElementType != FileElementType.Override || !Object.ReferenceEquals(m_parentFile, value.ParentFile));
-                m_baseElement = value;
+                // Value can be null if the value the element is overriding has not been defined.
+                // This is for example the case when we have a Device with a specific name, but that name is not defined in the station properties file
+                // and we override that with an element that is defined in the station properties file. (Check issue #172)
+                // Note: This only makes the error message not be an internal error, it does not make it possible to create an
+                //       element without all necessary fields defined.
+                if (value != null)
+                {
+                    // Assume not the same element.
+                    System.Diagnostics.Debug.Assert(!object.ReferenceEquals(value, this));
+                    // Assume not both override elements or elements are from different files.
+                    System.Diagnostics.Debug.Assert(this.ElementType != FileElementType.Override || value.ElementType != FileElementType.Override || !Object.ReferenceEquals(m_parentFile, value.ParentFile));
+                    m_baseElement = value;
+                }
             }
         }
 

--- a/source/StepBro.Core/ScriptData/FileElement.cs
+++ b/source/StepBro.Core/ScriptData/FileElement.cs
@@ -112,7 +112,7 @@ namespace StepBro.Core.ScriptData
                 // This is for example the case when we have a Device with a specific name, but that name is not defined in the station properties file
                 // and we override that with an element that is defined in the station properties file. (Check issue #172)
                 // Note: This only makes the error message not be an internal error, it does not make it possible to create an
-                //       element without all necessary fields defined.
+                //       element with an element that is not defined.
                 if (value != null)
                 {
                     // Assume not the same element.


### PR DESCRIPTION
Name of issue: If overridden port uses a different device from station properties and the original is not defined in station properties we get an error



Description of solution:
Create a null check that makes an error message more understandable


The following code (Assuming TargetPort is defined in the station properties file):
```
using StepBro.Streams;

public SerialPort portTarget = SerialPort()
{
    Device = UnknownPort,
    BaudRate = 460800,
    StopBits = One
}

override portTarget
{
    Device = TargetPort
}

procedure void test()
{
    log("Hello World!");
}
```

Gives the following error messages now:

```
2 parsing error(s)!
   BreakOverridePort.sbs line 3: No data for a device named "UnknownPort" can be found in the station properties.
   BreakOverridePort.sbs line 3: The object has no property named "Device".
```

It does not make it possible to define the initial SerialPort with an undefined element however it does give a readable error.