### PR TITLE
195 internal error when having an empty scope in a procedure

### DIFF
--- a/source/StepBro.Core/Parser/StepBroListener.Procedure.cs
+++ b/source/StepBro.Core/Parser/StepBroListener.Procedure.cs
@@ -446,6 +446,12 @@ namespace StepBro.Core.Parser
             {
                 trueStatement = subStatements[0].GetOnlyStatementCode();
             }
+
+            if (trueStatement == null)
+            {
+                trueStatement = Expression.Empty();
+            }
+
             Expression falseStatement = null;
             if (subStatements.Count == 2)
             {
@@ -457,6 +463,11 @@ namespace StepBro.Core.Parser
                 {
                     falseStatement = subStatements[1].GetOnlyStatementCode();
                 }
+            }
+
+            if (falseStatement == null)
+            {
+                falseStatement = Expression.Empty();
             }
 
             if (condition.IsValueType && condition.DataType.Type == typeof(bool))

--- a/source/Test/StepBro.Core.Test/Execution/TestProcedure_IfElse.cs
+++ b/source/Test/StepBro.Core.Test/Execution/TestProcedure_IfElse.cs
@@ -151,5 +151,57 @@ namespace StepBroCoreTest.Parser
             Assert.AreEqual(typeof(long), proc.ReturnType.Type);
             Assert.AreEqual(1, FileBuilder.LastInstance.Errors.ErrorCount);
         }
+
+        [TestMethod]
+        public void TestProcedureIfStatementEmpty()
+        {
+            var proc = FileBuilder.ParseProcedureExpectNoErrors(
+                "int Func(){ int a = 5; if(a == 5) {} return a;");
+            Assert.AreEqual(typeof(long), proc.ReturnType.Type);
+
+            object result = proc.Call();
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOfType(result, typeof(long));
+            Assert.AreEqual(5L, (long)result);
+        }
+
+        [TestMethod]
+        public void TestProcedureIfElseStatementEmpty()
+        {
+            var proc = FileBuilder.ParseProcedureExpectNoErrors(
+                "int Func(){ int a = 5; if(a == 5) {} else {} return a;");
+            Assert.AreEqual(typeof(long), proc.ReturnType.Type);
+
+            object result = proc.Call();
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOfType(result, typeof(long));
+            Assert.AreEqual(5L, (long)result);
+        }
+
+        [TestMethod]
+        public void TestProcedureIfElseWithIfStatementEmpty()
+        {
+            var proc = FileBuilder.ParseProcedureExpectNoErrors(
+                "int Func(){ int a = 5; if(a == 6) {} else { a = 7; } return a;");
+            Assert.AreEqual(typeof(long), proc.ReturnType.Type);
+
+            object result = proc.Call();
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOfType(result, typeof(long));
+            Assert.AreEqual(7L, (long)result);
+        }
+
+        [TestMethod]
+        public void TestProcedureIfElseWithElseStatementEmpty()
+        {
+            var proc = FileBuilder.ParseProcedureExpectNoErrors(
+                "int Func(){ int a = 5; if(a == 5) { a = 13; } else {} return a;");
+            Assert.AreEqual(typeof(long), proc.ReturnType.Type);
+
+            object result = proc.Call();
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOfType(result, typeof(long));
+            Assert.AreEqual(13L, (long)result);
+        }
     }
 }

--- a/source/Test/StepBro.Core.Test/Execution/TestProcedure_IfElse.cs
+++ b/source/Test/StepBro.Core.Test/Execution/TestProcedure_IfElse.cs
@@ -156,7 +156,7 @@ namespace StepBroCoreTest.Parser
         public void TestProcedureIfStatementEmpty()
         {
             var proc = FileBuilder.ParseProcedureExpectNoErrors(
-                "int Func(){ int a = 5; if(a == 5) {} return a;");
+                "int Func(){ int a = 5; if(a == 5) {} return a; }");
             Assert.AreEqual(typeof(long), proc.ReturnType.Type);
 
             object result = proc.Call();
@@ -169,7 +169,7 @@ namespace StepBroCoreTest.Parser
         public void TestProcedureIfElseStatementEmpty()
         {
             var proc = FileBuilder.ParseProcedureExpectNoErrors(
-                "int Func(){ int a = 5; if(a == 5) {} else {} return a;");
+                "int Func(){ int a = 5; if(a == 5) {} else {} return a; }");
             Assert.AreEqual(typeof(long), proc.ReturnType.Type);
 
             object result = proc.Call();
@@ -182,7 +182,7 @@ namespace StepBroCoreTest.Parser
         public void TestProcedureIfElseWithIfStatementEmpty()
         {
             var proc = FileBuilder.ParseProcedureExpectNoErrors(
-                "int Func(){ int a = 5; if(a == 6) {} else { a = 7; } return a;");
+                "int Func(){ int a = 5; if(a == 6) {} else { a = 7; } return a; }");
             Assert.AreEqual(typeof(long), proc.ReturnType.Type);
 
             object result = proc.Call();
@@ -195,7 +195,7 @@ namespace StepBroCoreTest.Parser
         public void TestProcedureIfElseWithElseStatementEmpty()
         {
             var proc = FileBuilder.ParseProcedureExpectNoErrors(
-                "int Func(){ int a = 5; if(a == 5) { a = 13; } else {} return a;");
+                "int Func(){ int a = 5; if(a == 5) { a = 13; } else {} return a; }");
             Assert.AreEqual(typeof(long), proc.ReturnType.Type);
 
             object result = proc.Call();


### PR DESCRIPTION
When an if statement had an empty body, an exception occurred before, this fixes it. (Same with else body)