### PR TITLE
121-create-parsing-error-when-device-is-not-found-in-station-properties

### DIFF
--- a/source/StepBro.Core/Parser/StepBroListener.cs
+++ b/source/StepBro.Core/Parser/StepBroListener.cs
@@ -533,7 +533,7 @@ namespace StepBro.Core.Parser
                         }
                         else
                         {
-                            if (!isSettableFromPropertyBlock)
+                            if (!isSettableFromPropertyBlock && !entry.Name.Equals(Constants.VARIABLE_DEVICE_REFERENCE, StringComparison.InvariantCultureIgnoreCase))
                             {
                                 errors.SymanticError(startToken.Line, startToken.Column, false, $"The object has no property named \"{entry.Name}\".");
                             }


### PR DESCRIPTION
Previously the following code, using command "stepbro FILENAME -v":

```
using StepBro.Streams;
using StepBro.TestInterface;

public SerialPort port = SerialPort()
{
    Device = portT,
    BaudRate = 460800,
    StopBits = One
}

public SerialTestConnection connection = SerialTestConnection()
{ 
    Stream = port, 
    CommandResponseTimeout = 2s
}
```

Gave two errors:
```
2 parsing error(s)!
   breakDeviceNotDefined.sbs line 4: No data for a device named "portT" can be found in the station properties.
   breakDeviceNotDefined.sbs line 4: The object has no property named "Device".
```

With this change it only gives one error:
```
1 parsing error(s)!
   breakDeviceNotDefined.sbs line 4: No data for a device named "portT" can be found in the station properties.
```

Only merge this if this is how we would like it to be. Otherwise the issue has already been fixed in some other commit.