### PR TITLE
229 make executionhelper have a log file which autosaves

### DIFF
--- a/source/Modules/StepBro.ExecutionHelper.Access/Access.cs
+++ b/source/Modules/StepBro.ExecutionHelper.Access/Access.cs
@@ -199,6 +199,18 @@ namespace StepBro.ExecutionHelper
             return true;
         }
 
+        public bool TurnOnSpaceSaving()
+        {
+            m_executionHelperPipe.Send(StepBro.ExecutionHelper.Messages.ShortCommand.TurnOnSpaceSaving);
+            return true;
+        }
+
+        public bool TurnOffSpaceSaving()
+        {
+            m_executionHelperPipe.Send(StepBro.ExecutionHelper.Messages.ShortCommand.TurnOffSpaceSaving);
+            return true;
+        }
+
         bool WaitForAcknowledge(ICallContext context)
         {
             bool result = false;

--- a/source/Modules/StepBro.ExecutionHelper.Access/Access.cs
+++ b/source/Modules/StepBro.ExecutionHelper.Access/Access.cs
@@ -67,7 +67,7 @@ namespace StepBro.ExecutionHelper
 
             m_executionHelperClosedEventHandler = (sender, e) =>
             {
-                context.Logger.LogError("VISA closed unexpectedly");
+                context.Logger.LogError("ExecutionHelper closed unexpectedly");
             };
 
             m_executionHelperPipe.OnConnectionClosed += m_executionHelperClosedEventHandler;

--- a/source/Modules/StepBro.ExecutionHelper.Access/Access.cs
+++ b/source/Modules/StepBro.ExecutionHelper.Access/Access.cs
@@ -187,9 +187,9 @@ namespace StepBro.ExecutionHelper
             return true;
         }
 
-        public bool PauseAutosave()
+        public bool SuspendAutosave()
         {
-            m_executionHelperPipe.Send(StepBro.ExecutionHelper.Messages.ShortCommand.PauseAutosave);
+            m_executionHelperPipe.Send(StepBro.ExecutionHelper.Messages.ShortCommand.SuspendAutosave);
             return true;
         }
 

--- a/source/Modules/StepBro.ExecutionHelper.Access/Access.cs
+++ b/source/Modules/StepBro.ExecutionHelper.Access/Access.cs
@@ -199,18 +199,6 @@ namespace StepBro.ExecutionHelper
             return true;
         }
 
-        public bool TurnOnSpaceSaving()
-        {
-            m_executionHelperPipe.Send(StepBro.ExecutionHelper.Messages.ShortCommand.TurnOnSpaceSaving);
-            return true;
-        }
-
-        public bool TurnOffSpaceSaving()
-        {
-            m_executionHelperPipe.Send(StepBro.ExecutionHelper.Messages.ShortCommand.TurnOffSpaceSaving);
-            return true;
-        }
-
         bool WaitForAcknowledge(ICallContext context)
         {
             bool result = false;

--- a/source/StepBro.ExecutionHelper/ExecutionHelperMessages.cs
+++ b/source/StepBro.ExecutionHelper/ExecutionHelperMessages.cs
@@ -13,9 +13,7 @@ namespace StepBro.ExecutionHelper.Messages
         CloseConnection,
         Acknowledge,
         SuspendAutosave,
-        ResumeAutosave,
-        TurnOnSpaceSaving,
-        TurnOffSpaceSaving
+        ResumeAutosave
     }
 
     public class Error

--- a/source/StepBro.ExecutionHelper/ExecutionHelperMessages.cs
+++ b/source/StepBro.ExecutionHelper/ExecutionHelperMessages.cs
@@ -12,7 +12,7 @@ namespace StepBro.ExecutionHelper.Messages
         CloseApplication,
         CloseConnection,
         Acknowledge,
-        PauseAutosave,
+        SuspendAutosave,
         ResumeAutosave,
         TurnOnSpaceSaving,
         TurnOffSpaceSaving

--- a/source/StepBro.ExecutionHelper/ExecutionHelperMessages.cs
+++ b/source/StepBro.ExecutionHelper/ExecutionHelperMessages.cs
@@ -13,7 +13,9 @@ namespace StepBro.ExecutionHelper.Messages
         CloseConnection,
         Acknowledge,
         PauseAutosave,
-        ResumeAutosave
+        ResumeAutosave,
+        TurnOnSpaceSaving,
+        TurnOffSpaceSaving
     }
 
     public class Error

--- a/source/StepBro.ExecutionHelper/MainForm.cs
+++ b/source/StepBro.ExecutionHelper/MainForm.cs
@@ -12,7 +12,7 @@ namespace StepBro.ExecutionHelper
         private bool m_closeRequested = false;
         private Dictionary<string, object> m_variables = new Dictionary<string, object>();
         private bool m_shouldAutoSave = true;
-        private bool m_shouldMinimizeSpaceUsage = true;
+        private bool m_shouldMinimizeSpaceUsage = false;
         private const string m_commandToRunOnStartupFileName = "CommandToRunOnStartup.sbd";
         private const string m_logFileName = "ExecutionHelperLog";
         private string m_logData = "";

--- a/source/StepBro.ExecutionHelper/MainForm.cs
+++ b/source/StepBro.ExecutionHelper/MainForm.cs
@@ -159,6 +159,7 @@ namespace StepBro.ExecutionHelper
                 }
                 else
                 {
+                    AddToLogData($"ReceivedData - Tried to create or set variable, but failed because data is null!");
                     m_pipe!.Send(new Error("Data in CreateOrSetVariable is null."));
                 }
             }

--- a/source/StepBro.ExecutionHelper/MainForm.cs
+++ b/source/StepBro.ExecutionHelper/MainForm.cs
@@ -91,7 +91,7 @@ namespace StepBro.ExecutionHelper
                 var cmd = JsonSerializer.Deserialize<ShortCommand>(received.Item2);
                 if (cmd == ShortCommand.CloseApplication)
                 {
-                    AddToLogData("ReceivedData - Received Close Request");
+                    AddToLogData("Receive: Close Request");
                     m_closeRequested = true;
                     this.BeginInvoke((MethodInvoker)delegate
                     {
@@ -99,30 +99,29 @@ namespace StepBro.ExecutionHelper
                         this.Close();
                     });
                 }
-                else if (cmd == ShortCommand.PauseAutosave)
+                else if (cmd == ShortCommand.SuspendAutosave)
                 {
-                    AddToLogData("ReceivedData - Received Pause Autosave");
+                    AddToLogData("Receive: Suspend Autosave");
                     m_shouldAutoSave = false;
                 }
                 else if (cmd == ShortCommand.ResumeAutosave)
                 {
-                    AddToLogData("ReceivedData - Received Resume Autosave");
+                    AddToLogData("Receive: Resume Autosave");
                     m_shouldAutoSave = true;
                 }
                 else if (cmd == ShortCommand.TurnOnSpaceSaving)
                 {
                     m_shouldMinimizeSpaceUsage = true;
-                    AddToLogData("ReceivedData - Turn on space saving");
+                    AddToLogData("Receive: Turn on space saving");
                 }
                 else if (cmd == ShortCommand.TurnOffSpaceSaving)
                 {
                     m_shouldMinimizeSpaceUsage = false;
-                    AddToLogData("ReceivedData - Turn off space saving");
+                    AddToLogData("Receive: Turn off space saving");
                 }
             }
             else if (received.Item1 == nameof(StepBro.ExecutionHelper.Messages.CreateOrSetVariable))
             {
-                AddToLogData("ReceivedData - Received Create or Set Variable");
                 var data = JsonSerializer.Deserialize<StepBro.ExecutionHelper.Messages.CreateOrSetVariable>(received.Item2);
                 if (data != null)
                 {
@@ -130,14 +129,14 @@ namespace StepBro.ExecutionHelper
                     bool isNumberKind = data.Value is System.Text.Json.JsonElement v && v.ValueKind == JsonValueKind.Number;
                     if (alreadyExists && isNumberKind)
                     {
-                        AddToLogData($"ReceivedData - Setting variable: {data.VariableName} to {data.Value}");
+                        AddToLogData($"ReceivedData - Setting variable: {data.VariableName} to: {data.Value}");
                         long value = 0;
                         Int64.TryParse(data.Value.ToString(), out value);
                         m_variables[data.VariableName] = value;
                     }
                     else if (alreadyExists)
                     {
-                        AddToLogData($"ReceivedData - Setting variable: {data.VariableName} to {data.Value}");
+                        AddToLogData($"ReceivedData - Setting variable: {data.VariableName} to: {data.Value}");
                         m_variables[data.VariableName] = data.Value;
                     }
                     else if (isNumberKind)
@@ -377,8 +376,17 @@ namespace StepBro.ExecutionHelper
                 if (m_shouldMinimizeSpaceUsage)
                 {
                     int index = dataToWrite.IndexOf('-');
-                    dataToWrite = dataToWrite.Substring(index + 2);
-                    timestamp = DateTime.Now.ToString("dd HH:mm:ss");
+
+                    if (index == -1)
+                    {
+                        index = dataToWrite.IndexOf(':');
+                    }
+
+                    if (index != -1)
+                    {
+                        dataToWrite = dataToWrite.Substring(index + 2);
+                        timestamp = DateTime.Now.ToString("dd HH:mm:ss");
+                    }
                 }
                 else
                 {

--- a/source/StepBro.ExecutionHelper/MainForm.cs
+++ b/source/StepBro.ExecutionHelper/MainForm.cs
@@ -12,6 +12,7 @@ namespace StepBro.ExecutionHelper
         private bool m_closeRequested = false;
         private Dictionary<string, object> m_variables = new Dictionary<string, object>();
         private bool m_shouldAutoSave = true;
+        private bool m_shouldMinimizeSpaceUsage = true;
         private const string m_commandToRunOnStartupFileName = "CommandToRunOnStartup.sbd";
         private const string m_logFileName = "ExecutionHelperLog";
         private string m_logData = "";
@@ -107,6 +108,16 @@ namespace StepBro.ExecutionHelper
                 {
                     AddToLogData("ReceivedData - Received Resume Autosave");
                     m_shouldAutoSave = true;
+                }
+                else if (cmd == ShortCommand.TurnOnSpaceSaving)
+                {
+                    m_shouldMinimizeSpaceUsage = true;
+                    AddToLogData("ReceivedData - Turn on space saving");
+                }
+                else if (cmd == ShortCommand.TurnOffSpaceSaving)
+                {
+                    m_shouldMinimizeSpaceUsage = false;
+                    AddToLogData("ReceivedData - Turn off space saving");
                 }
             }
             else if (received.Item1 == nameof(StepBro.ExecutionHelper.Messages.CreateOrSetVariable))
@@ -334,7 +345,7 @@ namespace StepBro.ExecutionHelper
                 }
             }
 
-            AddToLogData($"ReceivedData - Saved File {fileName}");
+            AddToLogData($"SaveFile - Saved File {fileName}");
         }
 
         private void SaveTimer_Tick(object sender, EventArgs e)
@@ -360,7 +371,19 @@ namespace StepBro.ExecutionHelper
         {
             lock(m_logLock)
             {
-                m_logData += $"{DateTime.Now.ToString("yyyy-MM-dd-HH-mm-ss")} - {data}\n";
+                string dataToWrite = data;
+                string timestamp = "";
+                if (m_shouldMinimizeSpaceUsage)
+                {
+                    int index = dataToWrite.IndexOf('-');
+                    dataToWrite = dataToWrite.Substring(index + 2);
+                    timestamp = DateTime.Now.ToString("dd HH:mm:ss");
+                }
+                else
+                {
+                    timestamp = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss");
+                }
+                m_logData += $"{timestamp} - {dataToWrite}\n";
             }
         }
     }

--- a/source/StepBro.ExecutionHelper/MainForm.cs
+++ b/source/StepBro.ExecutionHelper/MainForm.cs
@@ -317,10 +317,21 @@ namespace StepBro.ExecutionHelper
                 }
             }
 
-            using (FileStream fs = File.Create(fileName))
+            if (!File.Exists(fileName) || !shouldAppend)
             {
-                var dataInFile = new UTF8Encoding(true).GetBytes(dataToSave);
-                fs.Write(dataInFile, 0, dataInFile.Length);
+                using (FileStream fs = File.Create(fileName))
+                {
+                    var dataInFile = new UTF8Encoding(true).GetBytes(dataToSave);
+                    fs.Write(dataInFile, 0, dataInFile.Length);
+                }
+            }
+            else if (shouldAppend)
+            {
+                using (StreamWriter fs = File.AppendText(fileName))
+                {
+                    var dataInFile = new UTF8Encoding(true).GetBytes(dataToSave);
+                    fs.Write(dataToSave);
+                }
             }
 
             AddToLogData($"ReceivedData - Saved File {fileName}");
@@ -342,7 +353,7 @@ namespace StepBro.ExecutionHelper
                 localLogData = m_logData;
                 m_logData = "";
             }
-            SaveFile(m_logFileName + DateTime.Now.ToString("yyyy-MM-dd-HH"), localLogData);
+            SaveFile(m_logFileName + DateTime.Now.ToString("yyyy-MM-dd-HH") + ".sbd", localLogData, true);
         }
 
         private void AddToLogData(string data)

--- a/source/StepBro.ExecutionHelper/MainForm.cs
+++ b/source/StepBro.ExecutionHelper/MainForm.cs
@@ -349,7 +349,7 @@ namespace StepBro.ExecutionHelper
         {
             lock(m_logLock)
             {
-                m_logData += $"{data}\n";
+                m_logData += $"{DateTime.Now.ToString("yyyy-MM-dd-HH-mm-ss")} - {data}\n";
             }
         }
     }

--- a/source/StepBro.ExecutionHelper/MainForm.cs
+++ b/source/StepBro.ExecutionHelper/MainForm.cs
@@ -12,7 +12,6 @@ namespace StepBro.ExecutionHelper
         private bool m_closeRequested = false;
         private Dictionary<string, object> m_variables = new Dictionary<string, object>();
         private bool m_shouldAutoSave = true;
-        private bool m_shouldMinimizeSpaceUsage = false;
         private const string m_commandToRunOnStartupFileName = "CommandToRunOnStartup.sbd";
         private const string m_logFileName = "ExecutionHelperLog";
         private string m_logData = "";
@@ -108,16 +107,6 @@ namespace StepBro.ExecutionHelper
                 {
                     AddToLogData("Receive: Resume Autosave");
                     m_shouldAutoSave = true;
-                }
-                else if (cmd == ShortCommand.TurnOnSpaceSaving)
-                {
-                    m_shouldMinimizeSpaceUsage = true;
-                    AddToLogData("Receive: Turn on space saving");
-                }
-                else if (cmd == ShortCommand.TurnOffSpaceSaving)
-                {
-                    m_shouldMinimizeSpaceUsage = false;
-                    AddToLogData("Receive: Turn off space saving");
                 }
             }
             else if (received.Item1 == nameof(StepBro.ExecutionHelper.Messages.CreateOrSetVariable))
@@ -371,28 +360,8 @@ namespace StepBro.ExecutionHelper
         {
             lock(m_logLock)
             {
-                string dataToWrite = data;
-                string timestamp = "";
-                if (m_shouldMinimizeSpaceUsage)
-                {
-                    int index = dataToWrite.IndexOf('-');
-
-                    if (index == -1)
-                    {
-                        index = dataToWrite.IndexOf(':');
-                    }
-
-                    if (index != -1)
-                    {
-                        dataToWrite = dataToWrite.Substring(index + 2);
-                        timestamp = DateTime.Now.ToString("dd HH:mm:ss");
-                    }
-                }
-                else
-                {
-                    timestamp = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss");
-                }
-                m_logData += $"{timestamp} - {dataToWrite}\n";
+                string timestamp = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss");
+                m_logData += $"{timestamp} - {data}\n";
             }
         }
     }


### PR DESCRIPTION
Note: If we utilize ExecutionHelper a lot, then we may need an option to lessen the amount of text we write to the log file as it turns big fairly quickly.

With the following code:
```
using System;
using StepBro.ExecutionHelper.Access;
using "TestFramework.sbs";

public StepBro.ExecutionHelper.Access access = StepBro.ExecutionHelper.Access(){}

testlist testExe : TestSuite
{
    * proofOfConcept
}

void proofOfConcept() : TestCase
{
    bool result = access.CreateExecutionHelper();
    expect(result == true);

    result = access.CreateOrSetVariable("TestCounter", 0);
    expect(result == true);

    while (true) : Stoppable
    {
        result = access.IncrementVariable("TestCounter");
        expect(result == true);

        result = access.IncrementVariable("TestCounter");
        expect(result == true);

        int testCounter = (int)access.GetVariable("TestCounter");

        result = access.SaveFile("TestData.sbd");
        expect(result == true);

        int oldTestCounter = testCounter;
        result = access.CreateOrSetVariable("TestCounter", testCounter + 17);
        expect(result == true);

        testCounter = (int)access.GetVariable("TestCounter");
        expect(testCounter == oldTestCounter + 17);

        oldTestCounter = testCounter;
        result = access.LoadFile("TestData.sbd");
        testCounter = (int)access.GetVariable("TestCounter");
        expect(testCounter != oldTestCounter);
    }
}
```

It grows 25-30 KB per 5 seconds, 330 KB per minute, ~20 MB per hour, ~475 MB per day, ~3,3 GB per week, ~33,3 GB per 10 weeks, which may be realistic amount of time for it to run in long-time tests, and that's when you run the above code.

Whether we consider that alright or not is up to us to decide.

With space saving turned on it grows around 17,5 KB per 5 seconds instead.

After changes we use ~270 KB per minute, ~16 MB per hour, ~386 MB per day, ~2,7 GB per week, ~27 GB per 10 weeks, ~140,9 GB per year

After changes:
1 second: 4785,88 B
1 minute: ~287 KB
1 hour: ~17,2 MB
1 day: ~413,5 MB
1 week: ~2,9 GB
10 weeks: ~28,9 GB
1 year: ~150,9 GB