### PR TITLE
224-make-it-possible-to-run-sidekick-without-being-attached-to-cmdpowershell

### DIFF
--- a/source/StepBro.ConsoleSidekick.WinForms/MainForm.cs
+++ b/source/StepBro.ConsoleSidekick.WinForms/MainForm.cs
@@ -23,7 +23,6 @@ namespace StepBro.ConsoleSidekick.WinForms
         private bool m_moveToTop = true;
         private bool m_closeRequestedByConsole = false;
         private bool m_shouldAttach = true;
-        private int m_titleHeight = 0;
         private Pipe m_pipe = null;
         private Rect m_lastConsolePosition = new Rect();
         private IExecutionAccess m_executingScript = null;
@@ -159,9 +158,6 @@ namespace StepBro.ConsoleSidekick.WinForms
                     {
                         this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.Sizable;
                         m_shouldAttach = false;
-                        // Calculate height of the Windows title so we can use that when setting height of toolbar
-                        Rectangle screenRectangle = this.RectangleToScreen(this.ClientRectangle);
-                        m_titleHeight = screenRectangle.Top - this.Top + 9; // + 9 to ensure rounded corners do not remove any visibility
                     }
                 }
                 m_consoleWindow = nint.Parse(args[1], System.Globalization.NumberStyles.HexNumber);
@@ -181,6 +177,7 @@ namespace StepBro.ConsoleSidekick.WinForms
                 return;
             }
 
+            this.UpdateToolbarVisibility();
             m_forceResize = true;
         }
 
@@ -1113,6 +1110,7 @@ namespace StepBro.ConsoleSidekick.WinForms
 
         private void UpdateToolbarVisibility()
         {
+            int missingHeight = toolStripMain.Bounds.Bottom - this.ClientRectangle.Height;
             StepBro.UI.WinForms.CustomToolBar.ToolBar bottomVisible = null; // Actually the first visible in the list, as toolbars are added in reverse order.
             if (m_customToolStrips.Count > 0)
             {
@@ -1127,11 +1125,12 @@ namespace StepBro.ConsoleSidekick.WinForms
                 }
                 if (bottomVisible != null)
                 {
-                    this.Height = bottomVisible.Bounds.Bottom + m_titleHeight + 2;
+                    missingHeight = bottomVisible.Bounds.Bottom - this.ClientRectangle.Height;
+                    this.Height += missingHeight;
                     return;
                 }
             }
-            this.Height = toolStripMain.Bounds.Bottom + m_titleHeight + 2;
+            this.Height += missingHeight;
         }
 
         public static string ScripExecutionButtonTitle(bool showFullName, string element, string partner, string objectVariable, object[] args)

--- a/source/StepBro.ConsoleSidekick.WinForms/MainForm.cs
+++ b/source/StepBro.ConsoleSidekick.WinForms/MainForm.cs
@@ -1112,6 +1112,8 @@ namespace StepBro.ConsoleSidekick.WinForms
         {
             int missingHeight = toolStripMain.Bounds.Bottom - this.ClientRectangle.Height;
 
+            // We can not use Controls[0] here, as that could give an invisible toolbar
+            // so we search for the bottom-most visible toolbar
             StepBro.UI.WinForms.CustomToolBar.ToolBar bottomVisible = null; // Actually the first visible in the list, as toolbars are added in reverse order.
             if (m_customToolStrips.Count > 0)
             {

--- a/source/StepBro.ConsoleSidekick.WinForms/MainForm.cs
+++ b/source/StepBro.ConsoleSidekick.WinForms/MainForm.cs
@@ -1111,6 +1111,7 @@ namespace StepBro.ConsoleSidekick.WinForms
         private void UpdateToolbarVisibility()
         {
             int missingHeight = toolStripMain.Bounds.Bottom - this.ClientRectangle.Height;
+
             StepBro.UI.WinForms.CustomToolBar.ToolBar bottomVisible = null; // Actually the first visible in the list, as toolbars are added in reverse order.
             if (m_customToolStrips.Count > 0)
             {
@@ -1126,10 +1127,9 @@ namespace StepBro.ConsoleSidekick.WinForms
                 if (bottomVisible != null)
                 {
                     missingHeight = bottomVisible.Bounds.Bottom - this.ClientRectangle.Height;
-                    this.Height += missingHeight;
-                    return;
                 }
             }
+
             this.Height += missingHeight;
         }
 

--- a/source/StepBro.ConsoleSidekick.WinForms/MainForm.cs
+++ b/source/StepBro.ConsoleSidekick.WinForms/MainForm.cs
@@ -251,10 +251,6 @@ namespace StepBro.ConsoleSidekick.WinForms
 
         private void MoveWindows()
         {
-            if (!m_shouldAttach)
-            {
-                return;
-            }
             bool consoleActive = (GetForegroundWindow() == m_consoleWindow);
             if (consoleActive != m_isConsoleActive)
             {
@@ -690,7 +686,10 @@ namespace StepBro.ConsoleSidekick.WinForms
                 }
             }
 
-            MoveWindows();
+            if (m_shouldAttach)
+            {
+                MoveWindows();
+            }
         }
 
 

--- a/source/stepbro/CommandLineOptions.cs
+++ b/source/stepbro/CommandLineOptions.cs
@@ -41,5 +41,7 @@ namespace StepBro.Cmd
 
         [Option("sidekick", Default = false, HelpText = "Opens a sidekick window for interactive command input and script execution.")]
         public bool Sidekick { get; set; } = false;
+        [Option("no_attach", Default = false, HelpText = "Only usable with --sidekick. Makes sidekick not attach to console, useful if running with a non-supported terminal such as Win11 Terminal or VSCode.")]
+        public bool NoAttach { get; set; } = false;
     }
 }

--- a/source/stepbro/Program.cs
+++ b/source/stepbro/Program.cs
@@ -272,6 +272,10 @@ namespace StepBro.Cmd
                     var sidekick = new System.Diagnostics.Process();
                     sidekick.StartInfo.FileName = Path.Combine(folder, "StepBro.Sidekick.exe");
                     sidekick.StartInfo.Arguments = pipename;
+                    if (m_commandLineOptions.NoAttach)
+                    {
+                        sidekick.StartInfo.Arguments += " --no_attach";
+                    }
                     sidekickStarted = sidekick.Start();
 
 #if STOP_BEFORE_SIDEKICK


### PR DESCRIPTION
Add a --no_attach command line option, add height of title to the height of sidekick in this case.

Tested in the following ways:
With --no_attach and with no extra toolbars
Without --no_attach and with no extra toolbars
With --no_attach and with three extra toolbars
Without --no_attach and with three extra toolbars