### PR TITLE
255 make timeout accurate in instrumentusingbridgecs

### DIFF
--- a/source/Modules/StepBro.VISA/InstrumentUsingBridge.cs
+++ b/source/Modules/StepBro.VISA/InstrumentUsingBridge.cs
@@ -71,11 +71,13 @@ namespace StepBro.VISA
 
         public string FullName { get { return this.Name; } }
 
+        public TimeSpan ReadTimeout { get; set; } = TimeSpan.FromMilliseconds(2500);
+
         public bool Open([Implicit] ICallContext context = null, TimeSpan timeout = new TimeSpan())
         {
             if (timeout.Equals(new TimeSpan()))
             {
-                timeout = TimeSpan.FromMilliseconds(2500);
+                timeout = ReadTimeout;
             }
 
             string path = Assembly.GetExecutingAssembly().Location;
@@ -134,7 +136,7 @@ namespace StepBro.VISA
 
             started = m_visaPipe.IsConnected();
 
-            if (input.Item1 != nameof(VISABridge.Messages.SessionOpened))
+            if (input != null && input.Item1 != nameof(VISABridge.Messages.SessionOpened))
             {
                 context.ReportError("Received different message than SessionOpened.");
             }
@@ -150,7 +152,7 @@ namespace StepBro.VISA
         {
             if (timeout.Equals(new TimeSpan()))
             {
-                timeout = TimeSpan.FromMilliseconds(2500);
+                timeout = ReadTimeout;
             }
 
             m_visaPipe.Send(new VISABridge.Messages.CloseSession(m_resource));
@@ -168,7 +170,7 @@ namespace StepBro.VISA
                 Thread.Sleep(1);
             } while ((DateTime.Now - start) < timeout);
 
-            if (input.Item1 == nameof(VISABridge.Messages.ShortCommand))
+            if (input != null && input.Item1 == nameof(VISABridge.Messages.ShortCommand))
             {
                 var cmd = System.Text.Json.JsonSerializer.Deserialize<VISABridge.Messages.ShortCommand>(input.Item2);
                 if (cmd != VISABridge.Messages.ShortCommand.SessionClosed)
@@ -190,7 +192,7 @@ namespace StepBro.VISA
         {
             if (timeout.Equals(new TimeSpan()))
             {
-                timeout = TimeSpan.FromMilliseconds(2500);
+                timeout = ReadTimeout;
             }
 
             string received = null;
@@ -256,7 +258,7 @@ namespace StepBro.VISA
         {
             if (timeout.Equals(new TimeSpan()))
             {
-                timeout = TimeSpan.FromMilliseconds(2500);
+                timeout = ReadTimeout;
             }
 
             string received = null;
@@ -297,7 +299,7 @@ namespace StepBro.VISA
         {
             if (timeout.Equals(new TimeSpan()))
             {
-                timeout = TimeSpan.FromMilliseconds(2500);
+                timeout = TimeSpan.FromSeconds(20); // List Available Resources can often take quite a bit longer than 2,5s
             }
 
             string[] instruments = null;
@@ -319,7 +321,7 @@ namespace StepBro.VISA
                     Thread.Sleep(1);
                 } while ((DateTime.Now - start) < timeout);
 
-                if (input.Item1 == nameof(VISABridge.Messages.ConnectedInstruments))
+                if (input != null && input.Item1 == nameof(VISABridge.Messages.ConnectedInstruments))
                 {
                     var data = System.Text.Json.JsonSerializer.Deserialize<VISABridge.Messages.ConnectedInstruments>(input.Item2);
                     instruments = data.Instruments;

--- a/source/Modules/StepBro.VISA/InstrumentUsingBridge.cs
+++ b/source/Modules/StepBro.VISA/InstrumentUsingBridge.cs
@@ -71,8 +71,13 @@ namespace StepBro.VISA
 
         public string FullName { get { return this.Name; } }
 
-        public bool Open([Implicit] ICallContext context = null, int timeoutMs = 2500)
+        public bool Open([Implicit] ICallContext context = null, TimeSpan timeout = new TimeSpan())
         {
+            if (timeout.Equals(new TimeSpan()))
+            {
+                timeout = TimeSpan.FromMilliseconds(2500);
+            }
+
             string path = Assembly.GetExecutingAssembly().Location;
             var folder = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(path), ".."));
 
@@ -104,7 +109,7 @@ namespace StepBro.VISA
 
                 if (started)
                 {
-                    while (!m_visaPipe.IsConnected() && (DateTime.Now - start).TotalMilliseconds < timeoutMs)
+                    while (!m_visaPipe.IsConnected() && (DateTime.Now - start) < timeout)
                     {
                         int waitTimeMs = 200;
                         Thread.Sleep(waitTimeMs);
@@ -125,7 +130,7 @@ namespace StepBro.VISA
                 }
                 // Wait
                 Thread.Sleep(1);
-            } while ((DateTime.Now - start).TotalMilliseconds < timeoutMs);
+            } while ((DateTime.Now - start) < timeout);
 
             started = m_visaPipe.IsConnected();
 
@@ -141,8 +146,13 @@ namespace StepBro.VISA
             return started;
         }
 
-        public void Close([Implicit] ICallContext context = null, int timeoutMs = 2500)
+        public void Close([Implicit] ICallContext context = null, TimeSpan timeout = new TimeSpan())
         {
+            if (timeout.Equals(new TimeSpan()))
+            {
+                timeout = TimeSpan.FromMilliseconds(2500);
+            }
+
             m_visaPipe.Send(new VISABridge.Messages.CloseSession(m_resource));
 
             Tuple<string, string> input = null;
@@ -156,7 +166,7 @@ namespace StepBro.VISA
                 }
                 // Wait
                 Thread.Sleep(1);
-            } while ((DateTime.Now - start).TotalMilliseconds < timeoutMs);
+            } while ((DateTime.Now - start) < timeout);
 
             if (input.Item1 == nameof(VISABridge.Messages.ShortCommand))
             {
@@ -176,8 +186,13 @@ namespace StepBro.VISA
             }
         }
 
-        public string Query([Implicit] ICallContext context, string command, int timeoutMs = 2500)
+        public string Query([Implicit] ICallContext context, string command, TimeSpan timeout = new TimeSpan())
         {
+            if (timeout.Equals(new TimeSpan()))
+            {
+                timeout = TimeSpan.FromMilliseconds(2500);
+            }
+
             string received = null;
             if (m_sessionOpened)
             {
@@ -203,10 +218,10 @@ namespace StepBro.VISA
 
                     // Wait
                     Thread.Sleep(1);
-                } while ((DateTime.Now - start).TotalMilliseconds < timeoutMs);
+                } while ((DateTime.Now - start) < timeout);
 
                 if (input != null && input.Item1 == nameof(VISABridge.Messages.Received))
-                {
+                {   
                     var data = System.Text.Json.JsonSerializer.Deserialize<VISABridge.Messages.Received>(input.Item2);
                     received = data.Line.TrimEnd('\n','\r',' ');
                 }
@@ -235,8 +250,13 @@ namespace StepBro.VISA
             }
         }
 
-        public string Read([Implicit] ICallContext context, int timeoutMs = 2500)
+        public string Read([Implicit] ICallContext context, TimeSpan timeout = new TimeSpan())
         {
+            if (timeout.Equals(new TimeSpan()))
+            {
+                timeout = TimeSpan.FromMilliseconds(2500);
+            }
+
             string received = null;
             if (m_sessionOpened)
             {
@@ -253,7 +273,7 @@ namespace StepBro.VISA
                     }
                     // Wait
                     Thread.Sleep(1);
-                } while ((DateTime.Now - start).TotalMilliseconds < timeoutMs);
+                } while ((DateTime.Now - start) < timeout);
 
                 if (input.Item1 == nameof(VISABridge.Messages.Received))
                 {
@@ -269,8 +289,13 @@ namespace StepBro.VISA
             return received;
         }
 
-        public static string[] ListAvailableResources([Implicit] ICallContext context, int timeoutMs = 2500)
+        public static string[] ListAvailableResources([Implicit] ICallContext context, TimeSpan timeout = new TimeSpan())
         {
+            if (timeout.Equals(new TimeSpan()))
+            {
+                timeout = TimeSpan.FromMilliseconds(2500);
+            }
+
             string[] instruments = null;
 
             if (m_sessionOpened)
@@ -288,7 +313,7 @@ namespace StepBro.VISA
                     }
                     // Wait
                     Thread.Sleep(1);
-                } while ((DateTime.Now - start).TotalMilliseconds < timeoutMs);
+                } while ((DateTime.Now - start) < timeout);
 
                 if (input.Item1 == nameof(VISABridge.Messages.ConnectedInstruments))
                 {

--- a/source/Modules/StepBro.VISA/InstrumentUsingBridge.cs
+++ b/source/Modules/StepBro.VISA/InstrumentUsingBridge.cs
@@ -206,7 +206,11 @@ namespace StepBro.VISA
                     input = m_visaPipe.TryGetReceived();
 
                     // If we have received an answer that is not empty we break
-                    if (input != null && (!String.IsNullOrEmpty(System.Text.Json.JsonSerializer.Deserialize<VISABridge.Messages.Received>(input.Item2).Line) || input.Item1 != nameof(VISABridge.Messages.Received)))
+                    if (input != null &&
+                        (!String.IsNullOrEmpty(System.Text.Json.JsonSerializer.Deserialize<VISABridge.Messages.Received>(input.Item2).Line) ||
+                        input.Item1 != nameof(VISABridge.Messages.Received)) &&
+                        (System.Text.Json.JsonSerializer.Deserialize<VISABridge.Messages.Received>(input.Item2).Line[^1] == '\n' ||
+                         System.Text.Json.JsonSerializer.Deserialize<VISABridge.Messages.Received>(input.Item2).Line[^1] == '\r'))
                     {
                         break;
                     }
@@ -267,7 +271,11 @@ namespace StepBro.VISA
                 do
                 {
                     input = m_visaPipe.TryGetReceived();
-                    if (input != null)
+                    if (input != null && 
+                        (!String.IsNullOrEmpty(System.Text.Json.JsonSerializer.Deserialize<VISABridge.Messages.Received>(input.Item2).Line) || 
+                        input.Item1 != nameof(VISABridge.Messages.Received)) && 
+                        (System.Text.Json.JsonSerializer.Deserialize<VISABridge.Messages.Received>(input.Item2).Line[^1] == '\n' ||
+                         System.Text.Json.JsonSerializer.Deserialize<VISABridge.Messages.Received>(input.Item2).Line[^1] == '\r'))
                     {
                         break;
                     }

--- a/source/Modules/StepBro.VISA/InstrumentUsingBridge.cs
+++ b/source/Modules/StepBro.VISA/InstrumentUsingBridge.cs
@@ -208,9 +208,7 @@ namespace StepBro.VISA
                     // If we have received an answer that is not empty we break
                     if (input != null &&
                         (!String.IsNullOrEmpty(System.Text.Json.JsonSerializer.Deserialize<VISABridge.Messages.Received>(input.Item2).Line) ||
-                        input.Item1 != nameof(VISABridge.Messages.Received)) &&
-                        (System.Text.Json.JsonSerializer.Deserialize<VISABridge.Messages.Received>(input.Item2).Line[^1] == '\n' ||
-                         System.Text.Json.JsonSerializer.Deserialize<VISABridge.Messages.Received>(input.Item2).Line[^1] == '\r'))
+                        input.Item1 != nameof(VISABridge.Messages.Received)))
                     {
                         break;
                     }
@@ -273,9 +271,7 @@ namespace StepBro.VISA
                     input = m_visaPipe.TryGetReceived();
                     if (input != null && 
                         (!String.IsNullOrEmpty(System.Text.Json.JsonSerializer.Deserialize<VISABridge.Messages.Received>(input.Item2).Line) || 
-                        input.Item1 != nameof(VISABridge.Messages.Received)) && 
-                        (System.Text.Json.JsonSerializer.Deserialize<VISABridge.Messages.Received>(input.Item2).Line[^1] == '\n' ||
-                         System.Text.Json.JsonSerializer.Deserialize<VISABridge.Messages.Received>(input.Item2).Line[^1] == '\r'))
+                        input.Item1 != nameof(VISABridge.Messages.Received)))
                     {
                         break;
                     }
@@ -283,7 +279,7 @@ namespace StepBro.VISA
                     Thread.Sleep(1);
                 } while ((DateTime.Now - start) < timeout);
 
-                if (input.Item1 == nameof(VISABridge.Messages.Received))
+                if (input != null && input.Item1 == nameof(VISABridge.Messages.Received))
                 {
                     var data = System.Text.Json.JsonSerializer.Deserialize<VISABridge.Messages.Received>(input.Item2);
                     received = data.Line.TrimEnd('\n', '\r', ' ');

--- a/source/Modules/StepBro.VISA/InstrumentUsingBridge.cs
+++ b/source/Modules/StepBro.VISA/InstrumentUsingBridge.cs
@@ -278,7 +278,7 @@ namespace StepBro.VISA
                 if (input.Item1 == nameof(VISABridge.Messages.Received))
                 {
                     var data = System.Text.Json.JsonSerializer.Deserialize<VISABridge.Messages.Received>(input.Item2);
-                    received = data.Line;
+                    received = data.Line.TrimEnd('\n', '\r', ' ');
                 }
             }
             else

--- a/source/Modules/StepBro.VISA/InstrumentUsingBridge.cs
+++ b/source/Modules/StepBro.VISA/InstrumentUsingBridge.cs
@@ -186,25 +186,17 @@ namespace StepBro.VISA
             }
         }
 
-        public string Query([Implicit] ICallContext context, string command, TimeSpan timeout = new TimeSpan(), TimeSpan waitTimeBetweenSendReceived = new TimeSpan())
+        public string Query([Implicit] ICallContext context, string command, TimeSpan timeout = new TimeSpan())
         {
             if (timeout.Equals(new TimeSpan()))
             {
                 timeout = TimeSpan.FromMilliseconds(2500);
             }
 
-            if (waitTimeBetweenSendReceived.Equals(new TimeSpan()))
-            {
-                // This is necessary because long messages received from VISA can take a few milliseconds
-                // to be sent to StepBro.VISABridge, and we may receive only a small part of the message otherwise.
-                waitTimeBetweenSendReceived = TimeSpan.FromMilliseconds(5);
-            }
-
             string received = null;
             if (m_sessionOpened)
             {
                 m_visaPipe.Send(new VISABridge.Messages.Send(command));
-                Thread.Sleep(waitTimeBetweenSendReceived);
                 m_visaPipe.Send(VISABridge.Messages.ShortCommand.Receive);
 
                 Tuple<string, string> input = null;

--- a/source/StepBro.VISABridge/MainForm.cs
+++ b/source/StepBro.VISABridge/MainForm.cs
@@ -1,4 +1,5 @@
-﻿using NationalInstruments.Visa;
+﻿using Ivi.Visa;
+using NationalInstruments.Visa;
 using StepBro.Core.IPC;
 using StepBro.VISABridge.Messages;
 using System;
@@ -43,16 +44,20 @@ namespace StepBro.VISABridge
                             // Should not happen
                             break;
                         case ShortCommand.Receive:
-                            byte[] readData = { };
+                            List<byte> readData = new List<byte>();
+                            ReadStatus status = ReadStatus.Unknown;
                             try
                             {
-                                readData = m_session.RawIO.Read();
+                                while (status == ReadStatus.Unknown || status == ReadStatus.MaximumCountReached)
+                                {
+                                    readData.AddRange(m_session.RawIO.Read(1024, out status));
+                                }
                             }
                             catch
                             {
                                 // Do nothing - Timeout occurred
                             }
-                            m_pipe.Send(new Received(new UTF8Encoding(true).GetString(readData)));
+                            m_pipe.Send(new Received(new UTF8Encoding(true).GetString(readData.ToArray())));
                             break;
                     }
                     break;

--- a/source/StepBro.VISABridge/StepBroVISAMessages.cs
+++ b/source/StepBro.VISABridge/StepBroVISAMessages.cs
@@ -11,7 +11,8 @@ namespace StepBro.VISABridge.Messages
         None,
         GetInstrumentList,
         SessionClosed,
-        Receive
+        Receive,
+        ReadLine
     }
 
     public class ConnectedInstruments


### PR DESCRIPTION
Previously we counted down a variable once every cycle (With a sleep of 1ms so each cycle was at least 1ms, however most of the time each cycle could easily be 2-3ms or longer, meaning a 2,5s timeout could easily be 10-15 seconds)

Fix #255 