### PR TITLE
280 make it possible to save report to a specific file

### DIFF
--- a/source/StepBro.Core/Addons/IOutputFormatter.cs
+++ b/source/StepBro.Core/Addons/IOutputFormatter.cs
@@ -31,7 +31,8 @@ namespace StepBro.Core.Addons
         /// Create a complete textual report.
         /// </summary>
         /// <param name="report">The report data.</param>
-        void WriteReport(DataReport report);
+        /// <param name="fileName">Filename, null if no report file should be generated.</param>
+        void WriteReport(DataReport report, string fileName = null);
 
         /// <summary>
         /// Force writing all data to the underlying <seealso cref="ITextWriter"/> object.

--- a/source/StepBro.Core/Addons/IOutputFormatter.cs
+++ b/source/StepBro.Core/Addons/IOutputFormatter.cs
@@ -32,7 +32,7 @@ namespace StepBro.Core.Addons
         /// </summary>
         /// <param name="report">The report data.</param>
         /// <param name="fileName">Filename, null if no report file should be generated.</param>
-        void WriteReport(DataReport report, string fileName = null);
+        void WriteReport(DataReport report, bool shouldLogReport = false, string fileName = null);
 
         /// <summary>
         /// Force writing all data to the underlying <seealso cref="ITextWriter"/> object.

--- a/source/StepBro.Core/Addons/IOutputFormatter.cs
+++ b/source/StepBro.Core/Addons/IOutputFormatter.cs
@@ -31,6 +31,7 @@ namespace StepBro.Core.Addons
         /// Create a complete textual report.
         /// </summary>
         /// <param name="report">The report data.</param>
+        /// <param name="shouldLogReport">Whether report should be logged to console.</param>
         /// <param name="fileName">Filename, null if no report file should be generated.</param>
         void WriteReport(DataReport report, bool shouldLogReport = false, string fileName = null);
 

--- a/source/StepBro.Core/Addons/OutputAzurePipelineFormatAddon.cs
+++ b/source/StepBro.Core/Addons/OutputAzurePipelineFormatAddon.cs
@@ -207,7 +207,11 @@ namespace StepBro.Core.Addons
                     // RENAME FILE SO WE DO NOT OVERWRITE REPORT
                     if (m_reportFileName != null)
                     {
-                        System.IO.File.Move("report.sbr", $"report-{DateTime.Now.ToString("yyyy-MM-dd HH-mm-ss")}.sbr");
+                        if (m_reportFileName.Contains(System.IO.Path.DirectorySeparatorChar))
+                        {
+                            System.IO.Directory.CreateDirectory(Path.GetDirectoryName(m_reportFileName));
+                        }
+                        System.IO.File.Move("report.sbr", $"{m_reportFileName.Split(".sbr")[0]}-{DateTime.Now.ToString("yyyy-MM-dd HH-mm-ss")}.sbr");
                     }
                 }
                 finally

--- a/source/StepBro.Core/Addons/OutputAzurePipelineFormatAddon.cs
+++ b/source/StepBro.Core/Addons/OutputAzurePipelineFormatAddon.cs
@@ -30,6 +30,7 @@ namespace StepBro.Core.Addons
         private class Outputter : IOutputFormatter, ITextWriter
         {
             private string m_reportFileName = null;
+            private bool m_shouldLogReport = false;
             OutputFormatOptions m_options;
             readonly ITextWriter m_writer;
 
@@ -67,10 +68,11 @@ namespace StepBro.Core.Addons
                 return false;
             }
 
-            public void WriteReport(DataReport report, string fileName = null)
+            public void WriteReport(DataReport report, bool shouldLogReport = false, string fileName = null)
             {
                 // Use the filename provided, if it is null we will not write to a file
                 m_reportFileName = fileName;
+                m_shouldLogReport = shouldLogReport;
                 //bool oldCreateHighLevelLogSections = m_options.CreateHighLevelLogSections;
                 //m_options.CreateHighLevelLogSections = false;
                 try
@@ -287,7 +289,10 @@ namespace StepBro.Core.Addons
             // TODO: Utilize the CommandLineOptions.LogToFile option to log into a file here, as this writes the execution log as well
             void ITextWriter.Write(string text)
             {
-                System.Console.Write(text);
+                if (m_shouldLogReport)
+                {
+                    System.Console.Write(text);
+                }
 
                 if (m_reportFileName != null)
                 {
@@ -300,7 +305,10 @@ namespace StepBro.Core.Addons
 
             void ITextWriter.WriteLine(string text)
             {
-                System.Console.WriteLine(text);
+                if (m_shouldLogReport)
+                {
+                    System.Console.WriteLine(text);
+                }
 
                 if (m_reportFileName != null)
                 {

--- a/source/StepBro.Core/Addons/OutputAzurePipelineFormatAddon.cs
+++ b/source/StepBro.Core/Addons/OutputAzurePipelineFormatAddon.cs
@@ -29,6 +29,7 @@ namespace StepBro.Core.Addons
 
         private class Outputter : IOutputFormatter, ITextWriter
         {
+            private string m_reportFileName = null;
             OutputFormatOptions m_options;
             readonly ITextWriter m_writer;
 
@@ -66,8 +67,10 @@ namespace StepBro.Core.Addons
                 return false;
             }
 
-            public void WriteReport(DataReport report)
+            public void WriteReport(DataReport report, string fileName = null)
             {
+                // Use the filename provided, if it is null we will not write to a file
+                m_reportFileName = fileName;
                 //bool oldCreateHighLevelLogSections = m_options.CreateHighLevelLogSections;
                 //m_options.CreateHighLevelLogSections = false;
                 try
@@ -202,7 +205,10 @@ namespace StepBro.Core.Addons
                     }
 
                     // RENAME FILE SO WE DO NOT OVERWRITE REPORT
-                    System.IO.File.Move("report.sbr", $"report-{DateTime.Now.ToString("yyyy-MM-dd HH-mm-ss")}.sbr");
+                    if (m_reportFileName != null)
+                    {
+                        System.IO.File.Move("report.sbr", $"report-{DateTime.Now.ToString("yyyy-MM-dd HH-mm-ss")}.sbr");
+                    }
                 }
                 finally
                 {
@@ -279,9 +285,12 @@ namespace StepBro.Core.Addons
             {
                 System.Console.Write(text);
 
-                using (StreamWriter sw = System.IO.File.AppendText("report.sbr"))
+                if (m_reportFileName != null)
                 {
-                    sw.Write(text);
+                    using (StreamWriter sw = System.IO.File.AppendText("report.sbr"))
+                    {
+                        sw.Write(text);
+                    }
                 }
             }
 
@@ -289,9 +298,12 @@ namespace StepBro.Core.Addons
             {
                 System.Console.WriteLine(text);
 
-                using (StreamWriter sw = System.IO.File.AppendText("report.sbr"))
+                if (m_reportFileName != null)
                 {
-                    sw.WriteLine(text);
+                    using (StreamWriter sw = System.IO.File.AppendText("report.sbr"))
+                    {
+                        sw.WriteLine(text);
+                    }
                 }
             }
 

--- a/source/StepBro.Core/Addons/OutputAzurePipelineFormatAddon.cs
+++ b/source/StepBro.Core/Addons/OutputAzurePipelineFormatAddon.cs
@@ -280,7 +280,7 @@ namespace StepBro.Core.Addons
                 }
             }
 
-
+            // TODO: Utilize the CommandLineOptions.LogToFile option to log into a file here, as this writes the execution log as well
             void ITextWriter.Write(string text)
             {
                 System.Console.Write(text);

--- a/source/StepBro.Core/Addons/OutputConsoleWithColorsAddon.cs
+++ b/source/StepBro.Core/Addons/OutputConsoleWithColorsAddon.cs
@@ -39,6 +39,7 @@ namespace StepBro.Core.Addons
 
         public class TextToConsoleFormatter : IOutputFormatter, ITextWriter
         {
+            private string m_reportFileName = null;
             OutputFormatOptions m_options;
             ITextWriter m_writer = null;
 
@@ -102,8 +103,10 @@ namespace StepBro.Core.Addons
                 return false;
             }
 
-            public void WriteReport(DataReport report)
+            public void WriteReport(DataReport report, string fileName = null)
             {
+                // Use the filename provided, if it is null we will not write to a file
+                m_reportFileName = fileName;
                 try
                 {
                     // WRITE GROUPS
@@ -231,7 +234,10 @@ namespace StepBro.Core.Addons
                     }
 
                     // RENAME FILE SO WE DO NOT OVERWRITE REPORT
-                    System.IO.File.Move("report.sbr", $"report-{DateTime.Now.ToString("yyyy-MM-dd HH-mm-ss")}.sbr");
+                    if (m_reportFileName != null)
+                    {
+                        System.IO.File.Move("report.sbr", $"{m_reportFileName.Split(".sbr")[0]}-{DateTime.Now.ToString("yyyy-MM-dd HH-mm-ss")}.sbr");
+                    }
                 }
                 catch (Exception)
                 {
@@ -300,9 +306,12 @@ namespace StepBro.Core.Addons
             {
                 System.Console.Write(text);
 
-                using (StreamWriter sw = System.IO.File.AppendText("report.sbr"))
+                if (m_reportFileName != null)
                 {
-                    sw.Write(text);
+                    using (StreamWriter sw = System.IO.File.AppendText("report.sbr"))
+                    {
+                        sw.Write(text);
+                    }
                 }
             }
 
@@ -310,9 +319,12 @@ namespace StepBro.Core.Addons
             {
                 System.Console.WriteLine(text);
 
-                using (StreamWriter sw = System.IO.File.AppendText("report.sbr"))
+                if (m_reportFileName != null)
                 {
-                    sw.WriteLine(text);
+                    using (StreamWriter sw = System.IO.File.AppendText("report.sbr"))
+                    {
+                        sw.WriteLine(text);
+                    }
                 }
             }
         }

--- a/source/StepBro.Core/Addons/OutputConsoleWithColorsAddon.cs
+++ b/source/StepBro.Core/Addons/OutputConsoleWithColorsAddon.cs
@@ -40,6 +40,7 @@ namespace StepBro.Core.Addons
         public class TextToConsoleFormatter : IOutputFormatter, ITextWriter
         {
             private string m_reportFileName = null;
+            private bool m_shouldLogReport = false;
             OutputFormatOptions m_options;
             ITextWriter m_writer = null;
 
@@ -103,10 +104,11 @@ namespace StepBro.Core.Addons
                 return false;
             }
 
-            public void WriteReport(DataReport report, string fileName = null)
+            public void WriteReport(DataReport report, bool shouldLogReport = false, string fileName = null)
             {
                 // Use the filename provided, if it is null we will not write to a file
                 m_reportFileName = fileName;
+                m_shouldLogReport = shouldLogReport;
                 try
                 {
                     // WRITE GROUPS
@@ -309,7 +311,10 @@ namespace StepBro.Core.Addons
             // TODO: Utilize the CommandLineOptions.LogToFile option to log into a file here, as this writes the execution log as well
             void ITextWriter.Write(string text)
             {
-                System.Console.Write(text);
+                if (m_shouldLogReport)
+                {
+                    System.Console.Write(text);
+                }
 
                 if (m_reportFileName != null)
                 {
@@ -322,7 +327,10 @@ namespace StepBro.Core.Addons
 
             void ITextWriter.WriteLine(string text)
             {
-                System.Console.WriteLine(text);
+                if (m_shouldLogReport)
+                {
+                    System.Console.WriteLine(text);
+                }
 
                 if (m_reportFileName != null)
                 {

--- a/source/StepBro.Core/Addons/OutputConsoleWithColorsAddon.cs
+++ b/source/StepBro.Core/Addons/OutputConsoleWithColorsAddon.cs
@@ -236,6 +236,10 @@ namespace StepBro.Core.Addons
                     // RENAME FILE SO WE DO NOT OVERWRITE REPORT
                     if (m_reportFileName != null)
                     {
+                        if (m_reportFileName.Contains(System.IO.Path.DirectorySeparatorChar))
+                        {
+                            System.IO.Directory.CreateDirectory(Path.GetDirectoryName(m_reportFileName));
+                        }
                         System.IO.File.Move("report.sbr", $"{m_reportFileName.Split(".sbr")[0]}-{DateTime.Now.ToString("yyyy-MM-dd HH-mm-ss")}.sbr");
                     }
                 }

--- a/source/StepBro.Core/Addons/OutputConsoleWithColorsAddon.cs
+++ b/source/StepBro.Core/Addons/OutputConsoleWithColorsAddon.cs
@@ -302,6 +302,7 @@ namespace StepBro.Core.Addons
                 }
             }
 
+            // TODO: Utilize the CommandLineOptions.LogToFile option to log into a file here, as this writes the execution log as well
             void ITextWriter.Write(string text)
             {
                 System.Console.Write(text);

--- a/source/StepBro.Core/Addons/OutputHtmlAddon.cs
+++ b/source/StepBro.Core/Addons/OutputHtmlAddon.cs
@@ -73,7 +73,7 @@ namespace StepBro.Core.Addons
                 return false;
             }
 
-            public void WriteReport(DataReport report, string fileName = null)
+            public void WriteReport(DataReport report, bool shouldLogReport = false, string fileName = null)
             {
                 throw new NotImplementedException();
             }

--- a/source/StepBro.Core/Addons/OutputHtmlAddon.cs
+++ b/source/StepBro.Core/Addons/OutputHtmlAddon.cs
@@ -73,7 +73,7 @@ namespace StepBro.Core.Addons
                 return false;
             }
 
-            public void WriteReport(DataReport report)
+            public void WriteReport(DataReport report, string fileName = null)
             {
                 throw new NotImplementedException();
             }

--- a/source/StepBro.Core/Addons/OutputSimpleCleartextAddon.cs
+++ b/source/StepBro.Core/Addons/OutputSimpleCleartextAddon.cs
@@ -56,7 +56,7 @@ namespace StepBro.Core.Addons
                 return false;
             }
 
-            public void WriteReport(DataReport report, string fileName = null)
+            public void WriteReport(DataReport report, bool shouldLogReport = false, string fileName = null)
             {
                 throw new NotImplementedException();
             }

--- a/source/StepBro.Core/Addons/OutputSimpleCleartextAddon.cs
+++ b/source/StepBro.Core/Addons/OutputSimpleCleartextAddon.cs
@@ -56,7 +56,7 @@ namespace StepBro.Core.Addons
                 return false;
             }
 
-            public void WriteReport(DataReport report)
+            public void WriteReport(DataReport report, string fileName = null)
             {
                 throw new NotImplementedException();
             }

--- a/source/stepbro/CommandLineOptions.cs
+++ b/source/stepbro/CommandLineOptions.cs
@@ -29,7 +29,7 @@ namespace StepBro.Cmd
         [Option("save_log", Default = null, HelpText = "Saves the entire execution log in a text file in the specified folder.")]
         public string LogToFile { get; set; } = null;
 
-        [Option("save_report", Default = null, HelpText = "Saves the generated execution/test report(s) in a text file in the specified folder.")]
+        [Option("save_report", Default = null, HelpText = "Saves the generated execution/test report(s) in the specified file.")]
         public string ReportToFile { get; set; } = null;
 
         [Option("print_report", Default = false, HelpText = "Prints the generated execution/test report in the text format selected by the 'format' option.")]

--- a/source/stepbro/Program.cs
+++ b/source/stepbro/Program.cs
@@ -991,12 +991,15 @@ namespace StepBro.Cmd
 
             if (m_commandLineOptions.PrintReport && createdReport != null)
             {
-                using (FileStream fs = System.IO.File.Create("report.sbr"))
+                if (m_commandLineOptions.ReportToFile != null)
                 {
-                    byte[] generatedInfo = new UTF8Encoding(true).GetBytes($"--- BEGAN GENERATION AT {DateTime.Now.ToString("yyyy-MM-dd HH-mm-ss")} ---\n");
-                    fs.Write(generatedInfo, 0, generatedInfo.Length);
+                    using (FileStream fs = System.IO.File.Create("report.sbr"))
+                    {
+                        byte[] generatedInfo = new UTF8Encoding(true).GetBytes($"--- BEGAN GENERATION AT {DateTime.Now.ToString("yyyy-MM-dd HH-mm-ss")} ---\n");
+                        fs.Write(generatedInfo, 0, generatedInfo.Length);
+                    }
                 }
-                m_outputFormatter.WriteReport(createdReport);
+                m_outputFormatter.WriteReport(createdReport, m_commandLineOptions.ReportToFile);
             }
             else
             {

--- a/source/stepbro/Program.cs
+++ b/source/stepbro/Program.cs
@@ -993,10 +993,9 @@ namespace StepBro.Cmd
             {
                 if (m_commandLineOptions.ReportToFile != null)
                 {
-                    using (FileStream fs = System.IO.File.Create("report.sbr"))
+                    using (StreamWriter streamWriter = System.IO.File.AppendText("report.sbr"))
                     {
-                        byte[] generatedInfo = new UTF8Encoding(true).GetBytes($"--- BEGAN GENERATION AT {DateTime.Now.ToString("yyyy-MM-dd HH-mm-ss")} ---\n");
-                        fs.Write(generatedInfo, 0, generatedInfo.Length);
+                        streamWriter.WriteLine($"--- BEGAN GENERATION AT {DateTime.Now.ToString("yyyy-MM-dd HH-mm-ss")} ---\n");
                     }
                 }
                 m_outputFormatter.WriteReport(createdReport, m_commandLineOptions.PrintReport, m_commandLineOptions.ReportToFile);

--- a/source/stepbro/Program.cs
+++ b/source/stepbro/Program.cs
@@ -989,7 +989,7 @@ namespace StepBro.Cmd
             }
             FlushBufferedConsoleOutput();
 
-            if (m_commandLineOptions.PrintReport && createdReport != null)
+            if ((m_commandLineOptions.PrintReport || m_commandLineOptions.ReportToFile != null) && createdReport != null)
             {
                 if (m_commandLineOptions.ReportToFile != null)
                 {
@@ -999,7 +999,7 @@ namespace StepBro.Cmd
                         fs.Write(generatedInfo, 0, generatedInfo.Length);
                     }
                 }
-                m_outputFormatter.WriteReport(createdReport, m_commandLineOptions.ReportToFile);
+                m_outputFormatter.WriteReport(createdReport, m_commandLineOptions.PrintReport, m_commandLineOptions.ReportToFile);
             }
             else
             {

--- a/source/stepbro/Program.cs
+++ b/source/stepbro/Program.cs
@@ -993,9 +993,16 @@ namespace StepBro.Cmd
             {
                 if (m_commandLineOptions.ReportToFile != null)
                 {
-                    using (StreamWriter streamWriter = System.IO.File.AppendText("report.sbr"))
+                    try
                     {
-                        streamWriter.WriteLine($"--- BEGAN GENERATION AT {DateTime.Now.ToString("yyyy-MM-dd HH-mm-ss")} ---\n");
+                        using (StreamWriter streamWriter = System.IO.File.AppendText("report.sbr"))
+                        {
+                            streamWriter.WriteLine($"--- BEGAN GENERATION AT {DateTime.Now.ToString("yyyy-MM-dd HH-mm-ss")} ---\n");
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        ConsoleWriteErrorLine("Error occurred when creating report file. The following exception was thrown: " + e.Message);
                     }
                 }
                 m_outputFormatter.WriteReport(createdReport, m_commandLineOptions.PrintReport, m_commandLineOptions.ReportToFile);


### PR DESCRIPTION
With this, you need to say e.g. "--save_report report.sbr" for a report to be created. If you just say "--save_report" nothing will be created and if you do not say anything, nothing will be created either.