### PR TITLE
fix #295

### DIFF
--- a/source/StepBro.Core/Parser/StepBroListener.Expression.cs
+++ b/source/StepBro.Core/Parser/StepBroListener.Expression.cs
@@ -504,16 +504,16 @@ namespace StepBro.Core.Parser
                             // ArgumentExceptions are have shown to be semantic errors, not internal ones.
                             // If we find an ArgumentException that is an internal error, update this.
                             m_errors.SymanticError(context.Start.Line, context.Start.Column, false, $"Assignment failed: {ae.Message}");
-                            // Adding an empty expression to the expression data stack makes it possible
+                            // Adding an error expression to the expression data stack makes it possible
                             // to parse the rest of the script to catch further issues
-                            m_expressionData.Push(new SBExpressionData(Expression.Empty()));
+                            m_expressionData.Push(new SBExpressionData(HomeType.Immediate, SBExpressionType.ExpressionError));
                         }
                         catch (Exception e)
                         {
                             m_errors.InternalError(context.Start.Line, context.Start.Column, $"Assignment failed: {e.Message}");
-                            // Adding an empty expression to the expression data stack makes it possible
+                            // Adding an error expression to the expression data stack makes it possible
                             // to parse the rest of the script to catch further issues
-                            m_expressionData.Push(new SBExpressionData(Expression.Empty()));
+                            m_expressionData.Push(new SBExpressionData(HomeType.Immediate, SBExpressionType.ExpressionError));
                         }
                     }
                 }

--- a/source/StepBro.Core/Parser/StepBroListener.Expression.cs
+++ b/source/StepBro.Core/Parser/StepBroListener.Expression.cs
@@ -499,9 +499,21 @@ namespace StepBro.Core.Parser
                             var result = op.Resolve(this, first, last);
                             m_expressionData.Push(result);
                         }
-                        catch(Exception ex)
+                        catch (ArgumentException ae)
                         {
-                            m_errors.InternalError(first.Token.Line, first.Token.Column, $"Assignment between left: {first.DataType} and right: {last.DataType} failed with the exception message: {ex.Message}");
+                            // ArgumentExceptions are have shown to be semantic errors, not internal ones.
+                            // If we find an ArgumentException that is an internal error, update this.
+                            m_errors.SymanticError(context.Start.Line, context.Start.Column, false, $"Assignment failed: {ae.Message}");
+                            // Adding an empty expression to the expression data stack makes it possible
+                            // to parse the rest of the script to catch further issues
+                            m_expressionData.Push(new SBExpressionData(Expression.Empty()));
+                        }
+                        catch (Exception e)
+                        {
+                            m_errors.InternalError(context.Start.Line, context.Start.Column, $"Assignment failed: {e.Message}");
+                            // Adding an empty expression to the expression data stack makes it possible
+                            // to parse the rest of the script to catch further issues
+                            m_expressionData.Push(new SBExpressionData(Expression.Empty()));
                         }
                     }
                 }


### PR DESCRIPTION
Create a better error message and make it possible to parse through a error so we can find possible further errors.

There were cases where first.Token could be null previously, so instead using context.Start makes it possible to properly get lines and columns, and not get a NullReferenceException when we are trying to handle an exception from the assignment.

Furthermore, putting an empty expression on top of the expression stack makes it possible to continue parsing the rest of the script and find more errors!

Fix #295 