### PR TITLE
Adds "StepBro Station Properties.cfg" automatically to environment va…

### DIFF
--- a/source/StepBro Station Properties.cfg
+++ b/source/StepBro Station Properties.cfg
@@ -6,5 +6,11 @@ devices:
         devicetype: CommPort, 
         portname: "COM77",
         baudrate: 460800
+    },
+    TestPort2:
+    {
+        devicetype: CommPort,
+        portname: "COM127",
+        baudrate: 460800
     }
 }

--- a/source/StepBro Station Properties.cfg
+++ b/source/StepBro Station Properties.cfg
@@ -1,0 +1,10 @@
+devices:
+{
+    TestPort:
+    {
+        aliases: [AliasForTestPort],
+        devicetype: CommPort, 
+        portname: "COM77",
+        baudrate: 460800
+    }
+}

--- a/source/StepBroSetup.iss
+++ b/source/StepBroSetup.iss
@@ -58,11 +58,17 @@ Name: "{app}\scripts\smoketest"
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 [Files]
 Source: "bin\*"; DestDir: "{app}\bin"; Flags: ignoreversion recursesubdirs
+Source: "StepBro Station Properties.cfg"; DestDir: "{%USERPROFILE}\Documents"; Flags: onlyifdoesntexist
 
 [Registry]
 Root: HKLM; Subkey: "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"; \
     ValueType: expandsz; ValueName: "Path"; ValueData: "{olddata};{app}\bin"; \
     Check: NeedsAddPath(ExpandConstant('{app}\bin'))
+
+Root: HKLM; Subkey: "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"; \
+    ValueType:string; ValueName: "STEPBRO_STATION_PROPERTIES"; \
+    ValueData: "{%USERPROFILE}\Documents\StepBro Station Properties.cfg"; Flags: preservestringtype; \
+    Check: NeedsAddEnvironmentVariable('STEPBRO_STATION_PROPERTIES');
 
 ; Add 'My PDF Editor' menu item to the Shell menu for PDF files:
 Root: "HKCR"; Subkey: "SystemFileAssociations\.sbs\shell\Open with StepBro Workbench"; ValueType: none; ValueName: ""; ValueData: ""; Flags: uninsdeletekey
@@ -86,4 +92,9 @@ begin
   { look for the path with leading and trailing semicolon }
   { Pos() returns 0 if not found }
   Result := Pos(';' + Param + ';', ';' + OrigPath + ';') = 0;
+end;
+
+function NeedsAddEnvironmentVariable(Param: string): boolean;
+begin
+  Result := GetEnv(Param) = '';
 end;


### PR DESCRIPTION
Adds "StepBro Station Properties.cfg" automatically to environment variables (If it does not already exist) and automatically add a template file in "{$USERPROFILE}\Documents\StepBro Station Properties.cfg" (if it does not already exist)

Tested following cases:
- Both Env variable and file already exists = Nothing happens
- Env variable exists but file does not = File is created
- Env variable does not exist but file does = Environment variable is created
- Neither exist = Both are created

The file created is the exact one in the source folder called "StepBro Station Properties.cfg". If anything needs to be added to the template file, this is the file to add it to.