### PR TITLE
Implement 'filepath' keyword

### DIFF
--- a/source/StepBro.Core/Data/IReconstructable.cs
+++ b/source/StepBro.Core/Data/IReconstructable.cs
@@ -1,0 +1,31 @@
+﻿using StepBro.Core.Data;
+using StepBro.Core.Execution;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace StepBro.Core.Data
+{
+    /// <summary>
+    /// A delegate that reconstructs a reference to an object of the specified type.
+    /// </summary>
+    /// <param name="context"></param>
+    /// <param name="constructionData"></param>
+    /// <returns>The reconstructed object.</returns>
+    internal delegate object Reconstructor(IScriptCallContext context, object constructionData);
+
+    /// <summary>
+    /// Interface for an object that can create a delegate that can reconstruct a reference
+    /// to an object or an object with the same value as the current object.
+    /// </summary>
+    internal interface IReconstructable
+    {
+        /// <summary>
+        /// Gets a delegate that can reconstruct a reference to the current object or an equal object.
+        /// </summary>
+        /// <returns>A Tuple with the type of the reconstructed object, a reconstruction delegate, and an object to use as reconstruction seed.</returns>
+        Tuple<Type, Reconstructor, object> GetReconstructor();
+    }
+}

--- a/source/StepBro.Core/Data/IdentifierInfo.cs
+++ b/source/StepBro.Core/Data/IdentifierInfo.cs
@@ -11,6 +11,7 @@ namespace StepBro.Core.Data
         DotNetMethod,
         DotNetProperty,
         DotNetField,
+        ApplicationObject,
         /// <summary>
         /// A file (might be script file) by its name.
         /// </summary>

--- a/source/StepBro.Core/Data/TypeUtils.cs
+++ b/source/StepBro.Core/Data/TypeUtils.cs
@@ -379,5 +379,29 @@ namespace StepBro.Core.Data
             var propertyInfo = typeof(Expression).GetProperty("DebugView", BindingFlags.Instance | BindingFlags.NonPublic);
             return propertyInfo.GetValue(exp) as string;
         }
+    
+    
+        public static MethodInfo TryGetConvertOperator(this Type typeIn, Type typeOut)
+        {
+            Type[] searchTypes = new Type[] { typeIn };
+            Type[] searchTypesWithHome = new Type[] { typeof(IScriptFile), typeIn };
+
+            MethodInfo convert_mi = typeOut.GetMethod("Create", (BindingFlags.Public | BindingFlags.Static), null, searchTypesWithHome, Array.Empty<ParameterModifier>());
+            if (convert_mi != null && convert_mi.ReturnType == typeOut) return convert_mi;
+
+            convert_mi = typeIn.GetMethod("op_Explicit", (BindingFlags.Public | BindingFlags.Static), null, searchTypes, Array.Empty<ParameterModifier>());
+            if (convert_mi != null && convert_mi.ReturnType == typeOut) return convert_mi;
+
+            convert_mi = typeIn.GetMethod("op_Implicit", (BindingFlags.Public | BindingFlags.Static), null, searchTypes, Array.Empty<ParameterModifier>());
+            if (convert_mi != null && convert_mi.ReturnType == typeOut) return convert_mi;
+
+            convert_mi = typeOut.GetMethod("op_Explicit", (BindingFlags.Public | BindingFlags.Static), null, searchTypes, Array.Empty<ParameterModifier>());
+            if (convert_mi != null && convert_mi.ReturnType == typeOut) return convert_mi;
+
+            convert_mi = typeOut.GetMethod("op_Implicit", (BindingFlags.Public | BindingFlags.Static), null, searchTypes, Array.Empty<ParameterModifier>());
+            if (convert_mi != null && convert_mi.ReturnType == typeOut) return convert_mi;
+
+            return null;
+        }
     }
 }

--- a/source/StepBro.Core/Execution/ExecutionHelperMethods.cs
+++ b/source/StepBro.Core/Execution/ExecutionHelperMethods.cs
@@ -289,6 +289,11 @@ internal static class ExecutionHelperMethods
         return (value >= lower && value <= upper);
     }
 
+    public static IScriptFile GetFileReference(int id)
+    {
+        return ServiceManager.Global.Get<ILoadedFilesManager>().ListFiles<ScriptFile>().FirstOrDefault(f => f.UniqueID == id);
+    }
+
     public static T GetFileConstant<T>(IScriptCallContext context, int fileID, int id)
     {
         ScriptFile file = null;

--- a/source/StepBro.Core/Execution/ScriptUtils.cs
+++ b/source/StepBro.Core/Execution/ScriptUtils.cs
@@ -2,11 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Net.Mail;
-using System.Net;
 using System.Threading;
-using SharpCompress.Common;
-using StepBro.Core;
 using StepBro.Core.Addons;
 using StepBro.Core.Api;
 using StepBro.Core.Data;
@@ -182,7 +178,6 @@ namespace StepBro.Core.Execution
             }
             return result;
         }
-
 
         [Public]
         public static string GetOutputFileFolder()
@@ -669,6 +664,7 @@ namespace StepBro.Core.Execution
         }
 
         #endregion
+
     }
 
     //[Public]

--- a/source/StepBro.Core/File/FilePath.cs
+++ b/source/StepBro.Core/File/FilePath.cs
@@ -1,0 +1,71 @@
+﻿using StepBro.Core.Api;
+using StepBro.Core.Data;
+using StepBro.Core.Execution;
+using StepBro.Core.File;
+using StepBro.Core.Parser;
+using StepBro.Core.ScriptData;
+using System;
+
+namespace StepBro.Core.File
+{
+    [Public]
+    public class FilePath : IReconstructable
+    {
+        private string m_filepath;
+
+        public FilePath()
+        {
+            m_filepath = String.Empty;
+        }
+
+        internal FilePath(string path)
+        {
+            m_filepath = path;
+        }
+
+        public FilePath([Implicit] IScriptFile home, string path)
+        {
+            m_filepath = GetFullPath(home, path);
+        }
+
+        public string Value { get { return m_filepath; } }
+
+        public override string ToString()
+        {
+            return m_filepath;
+        }
+
+        public static implicit operator string(FilePath fp) => fp.m_filepath;
+        //public static explicit operator FilePath(string s) => new FilePath(s);
+
+        public static FilePath operator +(FilePath a, FilePath b) => new FilePath(System.IO.Path.Combine(a, b));
+        public static FilePath operator +(FilePath a, string b) => new FilePath(System.IO.Path.Combine(a, b));
+
+        static public FilePath Create([Implicit] IScriptFile home, string path)
+        {
+            if (home == null) { throw new ArgumentNullException(nameof(home)); }
+            return new FilePath(GetFullPath(home, path));
+        }
+
+        public static string GetFullPath(IScriptFile home, string filepath)
+        {
+            string error = null;
+            var result = home.FolderShortcuts.ListShortcuts().GetFullPath(filepath, ref error);
+            if (String.IsNullOrEmpty(result))
+            {
+                throw new ParsingErrorException("FilePath.GetFullPath failed: " + error);
+            }
+            return result;
+        }
+
+        Tuple<Type, Reconstructor, object> IReconstructable.GetReconstructor()
+        {
+            return new Tuple<Type, Reconstructor, object>(typeof(FilePath), Reconstruct, m_filepath);
+        }
+
+        private static object Reconstruct(IScriptCallContext context, object constructionData)
+        {
+            return new FilePath((string)constructionData);
+        }
+    }
+}

--- a/source/StepBro.Core/Parser/AssignmentOperators/AddAssignmentOperator.cs
+++ b/source/StepBro.Core/Parser/AssignmentOperators/AddAssignmentOperator.cs
@@ -14,6 +14,7 @@ namespace StepBro.Core.Parser.AssignmentOperators
         {
             switch (first.ReferencedType)
             {
+                case SBExpressionType.ApplicationObject:
                 case SBExpressionType.GlobalVariableReference:
                     break;
                 case SBExpressionType.LocalVariableReference:

--- a/source/StepBro.Core/Parser/BinaryOperators/PlusOperator.cs
+++ b/source/StepBro.Core/Parser/BinaryOperators/PlusOperator.cs
@@ -2,7 +2,10 @@
 using StepBro.Core.Execution;
 using System;
 using System.Collections;
+using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
+using System.Threading;
 
 namespace StepBro.Core.Parser.BinaryOperators
 {
@@ -134,6 +137,14 @@ namespace StepBro.Core.Parser.BinaryOperators
                     }
                     else
                     {
+                        Type[] searchTypes = new Type[] { first.DataType.Type, last.DataType.Type };
+                        MethodInfo op = first.DataType.Type.GetMethod("op_Addition", (BindingFlags.Public | BindingFlags.Static), null, searchTypes, Array.Empty<ParameterModifier>());
+                        if (op != null)
+                        {
+                            return new SBExpressionData(Expression.Call(op, first.ExpressionCode, last.ExpressionCode));
+                        }
+                        // TODO: run through other operator methods to check if any can be used if converting any of the arguments.
+
                         throw new NotImplementedException();
                     }
 

--- a/source/StepBro.Core/Parser/SBExpressionData.cs
+++ b/source/StepBro.Core/Parser/SBExpressionData.cs
@@ -15,6 +15,7 @@ namespace StepBro.Core.Parser
         Identifier,
         Expression,
         ThisReference,
+        ApplicationObject,
         GlobalVariableReference,
         LocalVariableReference,
         HostApplicationVariableReference,

--- a/source/StepBro.Core/Parser/StepBro.g4
+++ b/source/StepBro.Core/Parser/StepBro.g4
@@ -269,6 +269,7 @@ primitiveType
     |   DATETIME
     |   TIMESPAN
     |   STRING
+    |   FILEPATH
     |	OBJECT
     ;
 

--- a/source/StepBro.Core/Parser/StepBroLexer.g4
+++ b/source/StepBro.Core/Parser/StepBroLexer.g4
@@ -64,6 +64,7 @@ EXECUTION : 'execution' ;
 EXPECT : 'expect' ;
 FAIL : 'fail' ;
 FALSE : 'false' ;
+FILEPATH : 'filepath' ;
 FOREACH : 'foreach' ;
 FOR : 'for' ;
 FUNCTION : 'function' ;

--- a/source/StepBro.Core/Parser/StepBroListener.Procedure.cs
+++ b/source/StepBro.Core/Parser/StepBroListener.Procedure.cs
@@ -26,7 +26,7 @@ namespace StepBro.Core.Parser
         private List<ParameterData> m_parameters = null;
         private Stack<FileProcedure> m_procedureStack = new Stack<FileProcedure>();
         internal FileProcedure m_currentProcedure = null;   // The procedure currently being parsed.
-        private bool m_inFunctionScope = false;
+        internal bool m_inFunctionScope = false;
         private FileProcedure m_lastProcedure = null;       // The last procedure the parser ended parsing.
         private ProcedureParsingScope m_procedureBaseScope = null;
         private Stack<ProcedureParsingScope> m_scopeStack = new Stack<ProcedureParsingScope>();
@@ -1267,7 +1267,12 @@ namespace StepBro.Core.Parser
                     Expression.Convert(Expression.Constant(null), typeof(Logging.ILogger)));
             }
 
-            if (!m_currentProcedure.ReturnType.Type.IsAssignableFrom(code.Type))
+            var useableExpression = CheckAndConvertValueForAssignment(code, m_currentProcedure.ReturnType.Type);
+            if (useableExpression != null)
+            {
+                code = useableExpression;
+            }
+            else
             {
                 m_errors.SymanticError(context.Start.Line, context.Start.Column, false, "Expression data type is not compatible with the procedure return type.");
                 return;

--- a/source/StepBro.Core/Parser/StepBroListener.Type.cs
+++ b/source/StepBro.Core/Parser/StepBroListener.Type.cs
@@ -6,6 +6,7 @@ using StepBro.Core.Data;
 using StepBro.Core.Execution;
 using SBP = StepBro.Core.Parser.Grammar.StepBro;
 using static System.Net.Mime.MediaTypeNames;
+using StepBro.Core.File;
 
 namespace StepBro.Core.Parser
 {
@@ -58,6 +59,7 @@ namespace StepBro.Core.Parser
                     case SBP.DATETIME: type = typeof(DateTime); break;
                     case SBP.TIMESPAN: type = typeof(TimeSpan); break;
                     case SBP.STRING: type = typeof(string); break;
+                    case SBP.FILEPATH: type = typeof(FilePath); break;
                     case SBP.OBJECT: type = typeof(object); break;
                     default:
                         throw new NotImplementedException();
@@ -76,6 +78,7 @@ namespace StepBro.Core.Parser
                     case SBP.DATETIME: type = typeof(List<DateTime>); break;
                     case SBP.TIMESPAN: type = typeof(List<TimeSpan>); break;
                     case SBP.STRING: type = typeof(List<string>); break;
+                    case SBP.FILEPATH: type = typeof(List<FilePath>); break;
                     case SBP.OBJECT: type = typeof(List<object>); break;
                     default:
                         throw new NotImplementedException();
@@ -94,6 +97,7 @@ namespace StepBro.Core.Parser
                     case SBP.DATETIME: type = typeof(List<List<DateTime>>); break;
                     case SBP.TIMESPAN: type = typeof(List<List<TimeSpan>>); break;
                     case SBP.STRING: type = typeof(List<List<string>>); break;
+                    case SBP.FILEPATH: type = typeof(List<List<FilePath>>); break;
                     case SBP.OBJECT: type = typeof(List<List<object>>); break;
                     default:
                         throw new NotImplementedException();

--- a/source/Test/StepBro.Core.Test/Parser/TestFileParsing.cs
+++ b/source/Test/StepBro.Core.Test/Parser/TestFileParsing.cs
@@ -1236,6 +1236,30 @@ namespace StepBroCoreTest.Parser
             var result = taskContext.CallProcedure(procedure);
             Assert.AreEqual(11L, result);
         }
+
+        [TestMethod]
+        public void FileParsing_FilePathVariable()
+        {
+            var source = new StringBuilder();
+            source.AppendLine("namespace SayMyName;");
+            source.AppendLine("filepath myFile = @\"[this]\\sub\\zup\\script.sbs\";");
+            source.AppendLine("public string UseVariable()");
+            source.AppendLine("{");
+            source.AppendLine("    return myFile;");
+            source.AppendLine("}");
+
+            var files = FileBuilder.ParseFiles((ILogger)null, this.GetType().Assembly,
+                new Tuple<string, string>("myfile.sbs", source.ToString()));
+            Assert.AreEqual(1, files.Length);
+            Assert.AreEqual("myfile.sbs", files[0].FileName);
+            Assert.AreEqual(0, files[0].Errors.ErrorCount);
+            var procedure = files[0].ListElements().FirstOrDefault(p => p.Name == "UseVariable") as IFileProcedure;
+
+            var taskContext = ExecutionHelper.ExeContext(services: FileBuilder.LastServiceManager.Manager);
+            var result = taskContext.CallProcedure(procedure);
+            Assert.IsNotNull(result);
+            Assert.IsTrue(result is string);
+        }
     }
 }
 

--- a/source/Test/StepBro.Core.Test/Parser/TestFileVariables.cs
+++ b/source/Test/StepBro.Core.Test/Parser/TestFileVariables.cs
@@ -307,21 +307,24 @@ namespace StepBroCoreTest.Parser
         private long m_id;
         private long m_resetCounts = 0;
 
-        public DummyInstrumentClass([ObjectName] string objectName = "<no name>")
+        public DummyInstrumentClass([Implicit] IScriptFile home, [ObjectName] string objectName = "<no name>")
         {
+            if (home == null) throw new ArgumentNullException(nameof(home));
             m_id = m_nextInstanceID++;
             m_objectName = objectName;
         }
 
-        public DummyInstrumentClass(string[] names, [ObjectName] string objectName = "<no name>") : this()
+        public DummyInstrumentClass([Implicit] IScriptFile home, string[] names, [ObjectName] string objectName = "<no name>") : this(home)
         {
+            if (home == null) throw new ArgumentNullException(nameof(home));
             m_id = m_nextInstanceID++;
             m_objectName = objectName;
             m_names = names.ToList();
         }
 
-        public DummyInstrumentClass(long valueA, [ObjectName] string objectName = "<no name>") : this()
+        public DummyInstrumentClass([Implicit] IScriptFile home, long valueA, [ObjectName] string objectName = "<no name>") : this(home)
         {
+            if (home == null) throw new ArgumentNullException(nameof(home));
             m_id = m_nextInstanceID++;
             m_objectName = objectName;
             this.IntA = valueA;


### PR DESCRIPTION
Add keyword 'filepath' to the parser.
Add interface IReconstructable to help on object referencing in the generated script-code. 
Add use of conversion operators for assignment expressions. 
Add support for addition-operator usage in script add-expressions. 
Add support for implicit IScriptFile argument in object constructors. 
Use FilePath type for returning a file path from some script utility functions.